### PR TITLE
feat(branches-map): implement public /v1/public/branches-map endpoint to list active branches

### DIFF
--- a/internal/app/application.go
+++ b/internal/app/application.go
@@ -63,6 +63,8 @@ func (app *application) Mount() http.Handler {
 		//branch routes
 		app.Handlers.BranchHandlers.BranchRoutes(v1, m)
 
+		app.Handlers.BranchHandlers.PublicBranchRoutes(v1)
+
 		app.Handlers.InventoryHandlers.InventoryRoutes(v1, m)
 
 		app.Handlers.InstructorHandlers.InstructorRoutes(v1, m)

--- a/internal/modules/branches/domain/branches.go
+++ b/internal/modules/branches/domain/branches.go
@@ -80,3 +80,12 @@ type StatusCount struct {
 	Status string
 	Count  int64
 }
+
+type PublicBranchMapResponse struct {
+	BranchID  uuid.UUID `json:"branch_id"`
+	Name      string    `json:"name"`
+	Address   string    `json:"address"`
+	Latitude  float64   `json:"latitude"`
+	Longitude float64   `json:"longitude"`
+	Phone     string    `json:"phone"`
+}

--- a/internal/modules/branches/domain/repository.go
+++ b/internal/modules/branches/domain/repository.go
@@ -15,6 +15,7 @@ type BranchesRepository interface {
 	AddPaymentMethodsToBranch(ctx context.Context, branchID uuid.UUID, paymentLinks []PaymentMethodsBranch) error
 	Delete(ctx context.Context, branchID uuid.UUID) error
 	GetBranchStatusCount(ctx context.Context) (*BranchStatusCount, error)
+	GetPublicBranchesMap(ctx context.Context) ([]PublicBranchMapResponse, error)
 }
 
 type LocationRepository interface {

--- a/internal/modules/branches/domain/services.go
+++ b/internal/modules/branches/domain/services.go
@@ -16,6 +16,7 @@ type BranchesServicesInterface interface {
 	GetBranchByID(ctx context.Context, branchID uuid.UUID) (*Branch, error)
 	UpdateBranch(ctx context.Context, branch *Branch) error
 	GetBranchStatusCount(ctx context.Context) (*BranchStatusCount, error)
+	GetPublicBranchesMap(ctx context.Context) ([]PublicBranchMapResponse, error)
 }
 
 type LocationsServicesInterface interface {

--- a/internal/modules/branches/handlers/branches_handlers.go
+++ b/internal/modules/branches/handlers/branches_handlers.go
@@ -377,3 +377,28 @@ func (h *BranchHandlers) GetPaymentMethodsHandler(c *gin.Context) {
 	})
 
 }
+
+// ===================================================
+// =============== PUBLIC HANDLER (NO AUTH) ===========
+// ===================================================
+
+// @Summary		Get public active branches (Mapbox)
+// @Description	Returns a lightweight list of active branches for public map usage (no auth required)
+// @Tags			Public
+// @Produce		json
+// @Success		200	{object}	object{data=[]PublicBranchMapResponse}	"List of active branches for map display"
+// @Failure		500	{object}	object{error=string}					"Error: internal server error"
+// @Router			/v1/public/branches-map [get]
+func (h *BranchHandlers) GetPublicBranchesMapHandler(c *gin.Context) {
+	ctx := c.Request.Context()
+
+	branches, err := h.services.BranchesServices.GetPublicBranchesMap(ctx)
+	if err != nil {
+		h.services.LogErrors.InternalServerError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"data": branches,
+	})
+}

--- a/internal/modules/branches/handlers/payload.go
+++ b/internal/modules/branches/handlers/payload.go
@@ -101,3 +101,12 @@ type BranchResponseData struct {
 	OperatingHours   []branchdomain.OperatingHours       `json:"operating_hours" binding:"omitempty,dive"`
 	PaymentMethods   []branchdomain.PaymentMethodsBranch `json:"payment_methods" binding:"omitempty,dive"`
 }
+
+type PublicBranchMapResponse struct {
+	BranchID  uuid.UUID `json:"branch_id"`
+	Name      string    `json:"name"`
+	Address   string    `json:"address"`
+	Latitude  float64   `json:"latitude"`
+	Longitude float64   `json:"longitude"`
+	Phone     string    `json:"phone"`
+}

--- a/internal/modules/branches/handlers/routes.go
+++ b/internal/modules/branches/handlers/routes.go
@@ -15,6 +15,8 @@ type BranchHandlersInterface interface {
 	GetBranchByIDHandler(c *gin.Context)
 	UpdateBranchHandler(c *gin.Context)
 	GetBranchStatusCount(c *gin.Context)
+	GetPublicBranchesMapHandler(c *gin.Context)
+	PublicBranchRoutes(rg *gin.RouterGroup)
 }
 
 type BranchHandlers struct {
@@ -31,7 +33,6 @@ func (r *BranchHandlers) BranchRoutes(rg *gin.RouterGroup, m *auth.AuthMiddlewar
 		Use(m.AuthJwtTokenMiddleware())
 
 	{
-
 		branchGroup.GET("", m.RBACPermission("branches:list"), r.GetBranchesHandler)
 		branchGroup.GET("/:id", m.RBACPermission("branches:get"), r.GetBranchByIDHandler)
 		branchGroup.POST("", m.RBACPermission("branches:create"), r.CreateBranchHandler)
@@ -40,5 +41,12 @@ func (r *BranchHandlers) BranchRoutes(rg *gin.RouterGroup, m *auth.AuthMiddlewar
 
 		branchGroup.GET("/payment-methods", m.RBACPermission("branches:list"), r.GetPaymentMethodsHandler)
 		branchGroup.GET("/status", m.RBACPermission("branches:list"), r.GetBranchStatusCount)
+	}
+}
+
+func (r *BranchHandlers) PublicBranchRoutes(rg *gin.RouterGroup) {
+	publicGroup := rg.Group("/public")
+	{
+		publicGroup.GET("/branches-map", r.GetPublicBranchesMapHandler)
 	}
 }

--- a/internal/modules/branches/repository/branches_repository.go
+++ b/internal/modules/branches/repository/branches_repository.go
@@ -188,3 +188,22 @@ func (s *BranchesStore) Update(ctx context.Context, branch *branchdomain.Branch)
 		return nil
 	})
 }
+
+func (s *BranchesStore) GetPublicBranchesMap(ctx context.Context) ([]branchdomain.PublicBranchMapResponse, error) {
+	ctx, cancel := context.WithTimeout(ctx, db.QueryTimeoutDuration)
+	defer cancel()
+
+	var results []branchdomain.PublicBranchMapResponse
+
+	err := s.db.WithContext(ctx).
+		Model(&branchdomain.Branch{}).
+		Select("branch_id, name, address, latitude, longitude, phone").
+		Where("status = ?", "Active").
+		Find(&results).Error
+
+	if err != nil {
+		return nil, err
+	}
+
+	return results, nil
+}

--- a/internal/modules/branches/services/branches_services.go
+++ b/internal/modules/branches/services/branches_services.go
@@ -20,7 +20,6 @@ func NewBranchServices(store store.Storage, cfg config.Config) *BranchServices {
 		store:  store,
 		config: cfg,
 	}
-
 }
 
 func (s *BranchServices) CreateBranch(ctx context.Context, branch *branchdomain.Branch) error {
@@ -89,4 +88,16 @@ func (s *BranchServices) GetBranchStatusCount(ctx context.Context) (*branchdomai
 	}
 	counts.Total = counts.Active + counts.Inactive + counts.Maintenance
 	return counts, nil
+}
+
+// ===================================================
+// =============== PUBLIC SERVICE ====================
+// ===================================================
+
+func (s *BranchServices) GetPublicBranchesMap(ctx context.Context) ([]branchdomain.PublicBranchMapResponse, error) {
+	branches, err := s.store.Branches.GetPublicBranchesMap(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return branches, nil
 }


### PR DESCRIPTION
### **Description**

This PR introduces a public endpoint that returns all active branches in a lightweight format optimized for map display (e.g., Mapbox integration).

Added GET /v1/public/branches-map route under the branches module.

Implemented handler GetPublicBranchesMapHandler.

Added repository and service layers to fetch only branches with status Active.

Extended BranchHandlersInterface, BranchesRepository, and BranchesServicesInterface to support the new method.

Updated routing configuration in application.go to mount the public route.

### **Related Issue**

**HU: HU-W17**

**RF: RF-WB-20**

Public endpoint for displaying active branches on map (e-commerce & mobile app feature).

### **Motivation and Context**

This change enables client-side applications (web and mobile) to retrieve minimal branch data without requiring authentication.
The endpoint provides essential information (branch ID, name, address, latitude, longitude, and phone) needed for map markers, improving performance and reducing payload size.

### **How Has This Been Tested?**

Manually tested using Postman to ensure endpoint returns 200 OK.

Verified that only branches with status Active are returned.

Confirmed that endpoint is accessible without JWT token.

Tested integration with /v1/public/branches-map under local development environment (localhost:8081).

### **Screenshots (if appropriate):**

<img width="1284" height="804" alt="Screenshot 2025-10-31 213044" src="https://github.com/user-attachments/assets/31198669-fa16-4bf6-93a5-ff7365579026" />