### PR TITLE
feat(memberships): implement full CRUD endpoints for membership plans

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -47,7 +47,7 @@ type TokenConfig struct {
 
 func LoadConfig() *Config {
 	return &Config{
-		Addrs: env.GetString("ADDRS", ":8080"),
+		Addrs: env.GetString("ADDRS", ":8081"),
 		Db: dbConfig{
 			Dsn:          env.GetString("DB_ADDR", "postgres://admin:adminpassword@localhost/vitalfit?sslmode=disable"),
 			MaxOpenConns: env.GetInt("DB_MAX_OPEN_CONNS", 30),

--- a/config/config.go
+++ b/config/config.go
@@ -47,7 +47,7 @@ type TokenConfig struct {
 
 func LoadConfig() *Config {
 	return &Config{
-		Addrs: env.GetString("ADDRS", ":8081"),
+		Addrs: env.GetString("ADDRS", ":8080"),
 		Db: dbConfig{
 			Dsn:          env.GetString("DB_ADDR", "postgres://admin:adminpassword@localhost/vitalfit?sslmode=disable"),
 			MaxOpenConns: env.GetInt("DB_MAX_OPEN_CONNS", 30),

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -3730,6 +3730,331 @@ const docTemplate = `{
                 }
             }
         },
+        "/memberships/types": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Retrieves a list of all membership types.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Memberships"
+                ],
+                "summary": "List all membership types",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/membershipshandlers.MembershipResponse"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "error: Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Adds a new membership type (plan) to the system.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Memberships"
+                ],
+                "summary": "Create a new membership type",
+                "parameters": [
+                    {
+                        "description": "Membership creation payload",
+                        "name": "membership",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/membershipshandlers.CreateMembershipPayload"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Membership type created successfully",
+                        "schema": {
+                            "$ref": "#/definitions/membershipsdomain.MembershipType"
+                        }
+                    },
+                    "400": {
+                        "description": "error: Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "error: Conflict",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "error: Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/memberships/types/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Retrieves a single membership type by its UUID.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Memberships"
+                ],
+                "summary": "Get membership type by ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Membership Type UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "$ref": "#/definitions/membershipshandlers.MembershipResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "error: Bad Request - Invalid ID",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "error: Not Found - Membership type not found",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "error: Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Updates an existing membership type’s details.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Memberships"
+                ],
+                "summary": "Update a membership type",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Membership Type UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Membership update payload",
+                        "name": "membership",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/membershipshandlers.UpdateMembershipPayload"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Membership type updated successfully",
+                        "schema": {
+                            "$ref": "#/definitions/membershipsdomain.MembershipType"
+                        }
+                    },
+                    "400": {
+                        "description": "error: Bad Request - Invalid ID or payload",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "error: Not Found - Membership type not found",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "error: Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Soft deletes a membership type from the system (sets inactive).",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Memberships"
+                ],
+                "summary": "Delete a membership type",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Membership Type UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "error: Bad Request - Invalid ID",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "error: Not Found - Membership type not found",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "error: Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/public/branches-map": {
             "get": {
                 "description": "Retrieves a list of public branches with minimal information for map display.",
@@ -5476,6 +5801,106 @@ const docTemplate = `{
                 },
                 "name": {
                     "type": "string"
+                }
+            }
+        },
+        "membershipsdomain.MembershipType": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "deleted_at": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "duration_days": {
+                    "type": "integer"
+                },
+                "is_active": {
+                    "type": "boolean"
+                },
+                "membership_type_id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "price": {
+                    "type": "number"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "membershipshandlers.CreateMembershipPayload": {
+            "type": "object",
+            "required": [
+                "duration_days",
+                "name",
+                "price"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "duration_days": {
+                    "type": "integer"
+                },
+                "is_active": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "price": {
+                    "type": "number"
+                }
+            }
+        },
+        "membershipshandlers.MembershipResponse": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "duration_days": {
+                    "type": "integer"
+                },
+                "is_active": {
+                    "type": "boolean"
+                },
+                "membership_type_id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "price": {
+                    "type": "number"
+                }
+            }
+        },
+        "membershipshandlers.UpdateMembershipPayload": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "duration_days": {
+                    "type": "integer"
+                },
+                "is_active": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "price": {
+                    "type": "number"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -3722,6 +3722,331 @@
                 }
             }
         },
+        "/memberships/types": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Retrieves a list of all membership types.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Memberships"
+                ],
+                "summary": "List all membership types",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/membershipshandlers.MembershipResponse"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "error: Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Adds a new membership type (plan) to the system.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Memberships"
+                ],
+                "summary": "Create a new membership type",
+                "parameters": [
+                    {
+                        "description": "Membership creation payload",
+                        "name": "membership",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/membershipshandlers.CreateMembershipPayload"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Membership type created successfully",
+                        "schema": {
+                            "$ref": "#/definitions/membershipsdomain.MembershipType"
+                        }
+                    },
+                    "400": {
+                        "description": "error: Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "error: Conflict",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "error: Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/memberships/types/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Retrieves a single membership type by its UUID.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Memberships"
+                ],
+                "summary": "Get membership type by ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Membership Type UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "$ref": "#/definitions/membershipshandlers.MembershipResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "error: Bad Request - Invalid ID",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "error: Not Found - Membership type not found",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "error: Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Updates an existing membership type’s details.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Memberships"
+                ],
+                "summary": "Update a membership type",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Membership Type UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Membership update payload",
+                        "name": "membership",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/membershipshandlers.UpdateMembershipPayload"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Membership type updated successfully",
+                        "schema": {
+                            "$ref": "#/definitions/membershipsdomain.MembershipType"
+                        }
+                    },
+                    "400": {
+                        "description": "error: Bad Request - Invalid ID or payload",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "error: Not Found - Membership type not found",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "error: Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Soft deletes a membership type from the system (sets inactive).",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Memberships"
+                ],
+                "summary": "Delete a membership type",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Membership Type UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "error: Bad Request - Invalid ID",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "error: Not Found - Membership type not found",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "error: Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/public/branches-map": {
             "get": {
                 "description": "Retrieves a list of public branches with minimal information for map display.",
@@ -5468,6 +5793,106 @@
                 },
                 "name": {
                     "type": "string"
+                }
+            }
+        },
+        "membershipsdomain.MembershipType": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "deleted_at": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "duration_days": {
+                    "type": "integer"
+                },
+                "is_active": {
+                    "type": "boolean"
+                },
+                "membership_type_id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "price": {
+                    "type": "number"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "membershipshandlers.CreateMembershipPayload": {
+            "type": "object",
+            "required": [
+                "duration_days",
+                "name",
+                "price"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "duration_days": {
+                    "type": "integer"
+                },
+                "is_active": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "price": {
+                    "type": "number"
+                }
+            }
+        },
+        "membershipshandlers.MembershipResponse": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "duration_days": {
+                    "type": "integer"
+                },
+                "is_active": {
+                    "type": "boolean"
+                },
+                "membership_type_id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "price": {
+                    "type": "number"
+                }
+            }
+        },
+        "membershipshandlers.UpdateMembershipPayload": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "duration_days": {
+                    "type": "integer"
+                },
+                "is_active": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "price": {
+                    "type": "number"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -905,6 +905,72 @@ definitions:
       name:
         type: string
     type: object
+  membershipsdomain.MembershipType:
+    properties:
+      created_at:
+        type: string
+      deleted_at:
+        type: string
+      description:
+        type: string
+      duration_days:
+        type: integer
+      is_active:
+        type: boolean
+      membership_type_id:
+        type: string
+      name:
+        type: string
+      price:
+        type: number
+      updated_at:
+        type: string
+    type: object
+  membershipshandlers.CreateMembershipPayload:
+    properties:
+      description:
+        type: string
+      duration_days:
+        type: integer
+      is_active:
+        type: boolean
+      name:
+        type: string
+      price:
+        type: number
+    required:
+    - duration_days
+    - name
+    - price
+    type: object
+  membershipshandlers.MembershipResponse:
+    properties:
+      description:
+        type: string
+      duration_days:
+        type: integer
+      is_active:
+        type: boolean
+      membership_type_id:
+        type: string
+      name:
+        type: string
+      price:
+        type: number
+    type: object
+  membershipshandlers.UpdateMembershipPayload:
+    properties:
+      description:
+        type: string
+      duration_days:
+        type: integer
+      is_active:
+        type: boolean
+      name:
+        type: string
+      price:
+        type: number
+    type: object
   productsdomain.Service:
     properties:
       banners:
@@ -3563,6 +3629,210 @@ paths:
       summary: Update a banner
       tags:
       - Marketing
+  /memberships/types:
+    get:
+      description: Retrieves a list of all membership types.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/definitions/membershipshandlers.MembershipResponse'
+                type: array
+            type: object
+        "500":
+          description: 'error: Internal Server Error'
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+      security:
+      - ApiKeyAuth: []
+      summary: List all membership types
+      tags:
+      - Memberships
+    post:
+      consumes:
+      - application/json
+      description: Adds a new membership type (plan) to the system.
+      parameters:
+      - description: Membership creation payload
+        in: body
+        name: membership
+        required: true
+        schema:
+          $ref: '#/definitions/membershipshandlers.CreateMembershipPayload'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Membership type created successfully
+          schema:
+            $ref: '#/definitions/membershipsdomain.MembershipType'
+        "400":
+          description: 'error: Bad Request'
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+        "409":
+          description: 'error: Conflict'
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+        "500":
+          description: 'error: Internal Server Error'
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+      security:
+      - ApiKeyAuth: []
+      summary: Create a new membership type
+      tags:
+      - Memberships
+  /memberships/types/{id}:
+    delete:
+      description: Soft deletes a membership type from the system (sets inactive).
+      parameters:
+      - description: Membership Type UUID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: 'error: Bad Request - Invalid ID'
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+        "404":
+          description: 'error: Not Found - Membership type not found'
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+        "500":
+          description: 'error: Internal Server Error'
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+      security:
+      - ApiKeyAuth: []
+      summary: Delete a membership type
+      tags:
+      - Memberships
+    get:
+      description: Retrieves a single membership type by its UUID.
+      parameters:
+      - description: Membership Type UUID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            properties:
+              data:
+                $ref: '#/definitions/membershipshandlers.MembershipResponse'
+            type: object
+        "400":
+          description: 'error: Bad Request - Invalid ID'
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+        "404":
+          description: 'error: Not Found - Membership type not found'
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+        "500":
+          description: 'error: Internal Server Error'
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+      security:
+      - ApiKeyAuth: []
+      summary: Get membership type by ID
+      tags:
+      - Memberships
+    put:
+      consumes:
+      - application/json
+      description: Updates an existing membership type’s details.
+      parameters:
+      - description: Membership Type UUID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Membership update payload
+        in: body
+        name: membership
+        required: true
+        schema:
+          $ref: '#/definitions/membershipshandlers.UpdateMembershipPayload'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Membership type updated successfully
+          schema:
+            $ref: '#/definitions/membershipsdomain.MembershipType'
+        "400":
+          description: 'error: Bad Request - Invalid ID or payload'
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+        "404":
+          description: 'error: Not Found - Membership type not found'
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+        "500":
+          description: 'error: Internal Server Error'
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+      security:
+      - ApiKeyAuth: []
+      summary: Update a membership type
+      tags:
+      - Memberships
   /public/branches-map:
     get:
       description: Retrieves a list of public branches with minimal information for

--- a/internal/migrate/migrations/000019_create_membership_types_table.down.sql
+++ b/internal/migrate/migrations/000019_create_membership_types_table.down.sql
@@ -1,0 +1,7 @@
+-- ----------------------------------------------------
+-- 000019_create_membership_types_table.down.sql
+-- Module: Memberships
+-- Description: Drops the membership_types table.
+-- ----------------------------------------------------
+
+DROP TABLE IF EXISTS membership_types CASCADE;

--- a/internal/migrate/migrations/000019_create_membership_types_table.up.sql
+++ b/internal/migrate/migrations/000019_create_membership_types_table.up.sql
@@ -1,0 +1,17 @@
+-- ----------------------------------------------------
+-- 000019_create_membership_types_table.up.sql
+-- Module: Memberships
+-- Description: Creates the membership_types table used for plan management.
+-- ----------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS membership_types (
+    membership_type_id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    name VARCHAR(100) UNIQUE NOT NULL,
+    description TEXT,
+    duration_days INT NOT NULL,
+    price DECIMAL(10, 2) NOT NULL,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMP DEFAULT NOW(),
+    updated_at TIMESTAMP,
+    deleted_at TIMESTAMP
+);

--- a/internal/modules/memberships/domain/membership.go
+++ b/internal/modules/memberships/domain/membership.go
@@ -1,1 +1,23 @@
 package membershipsdomain
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type MembershipType struct {
+	MembershipTypeID uuid.UUID  `gorm:"type:uuid;primaryKey;default:uuid_generate_v4()" json:"membership_type_id"`
+	Name             string     `gorm:"type:varchar(100);unique;not null" json:"name"`
+	Description      string     `gorm:"type:text" json:"description"`
+	DurationDays     int        `gorm:"not null" json:"duration_days"`
+	Price            float64    `gorm:"type:numeric(10,2);not null" json:"price"`
+	IsActive         bool       `gorm:"not null;default:true" json:"is_active"`
+	CreatedAt        time.Time  `gorm:"autoCreateTime" json:"created_at"`
+	UpdatedAt        time.Time  `gorm:"autoUpdateTime" json:"updated_at"`
+	DeletedAt        *time.Time `gorm:"index" json:"deleted_at,omitempty"`
+}
+
+func (MembershipType) TableName() string {
+	return "membership_types"
+}

--- a/internal/modules/memberships/domain/repository.go
+++ b/internal/modules/memberships/domain/repository.go
@@ -1,4 +1,17 @@
 package membershipsdomain
 
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
 type MembershipsRepository interface {
+	CreateMembershipType(ctx context.Context, membership *MembershipType) error
+	CreateMembershipTypeTX(ctx context.Context, tx *gorm.DB, membership *MembershipType) error
+	UpdateMembershipType(ctx context.Context, membership *MembershipType) error
+	DeleteMembershipType(ctx context.Context, id uuid.UUID) error
+	GetMembershipTypeByID(ctx context.Context, id uuid.UUID) (*MembershipType, error)
+	GetMembershipTypes(ctx context.Context) ([]*MembershipType, error)
 }

--- a/internal/modules/memberships/domain/service.go
+++ b/internal/modules/memberships/domain/service.go
@@ -1,4 +1,15 @@
 package membershipsdomain
 
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
 type MembershipsServiceInterface interface {
+	CreateMembershipType(ctx context.Context, membership *MembershipType) error
+	UpdateMembershipType(ctx context.Context, membership *MembershipType) error
+	DeleteMembershipType(ctx context.Context, id uuid.UUID) error
+	GetMembershipTypeByID(ctx context.Context, id uuid.UUID) (*MembershipType, error)
+	GetMembershipTypes(ctx context.Context) ([]*MembershipType, error)
 }

--- a/internal/modules/memberships/handlers/membership_handler.go
+++ b/internal/modules/memberships/handlers/membership_handler.go
@@ -1,1 +1,205 @@
 package membershipshandlers
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	shared_errors "github.com/vitalfit/api/internal/shared/errors"
+)
+
+// @Summary		Create a new membership type
+// @Description	Adds a new membership type (plan) to the system.
+// @Tags			Memberships
+// @Accept			json
+// @Produce		json
+// @Security		ApiKeyAuth
+// @Param			membership	body		CreateMembershipPayload				true	"Membership creation payload"
+// @Success		201			{object}	membershipsdomain.MembershipType	"Membership type created successfully"
+// @Failure		400			{object}	object{error=string}				"error: Bad Request"
+// @Failure		409			{object}	object{error=string}				"error: Conflict"
+// @Failure		500			{object}	object{error=string}				"error: Internal Server Error"
+// @Router			/memberships/types [post]
+func (h *MembershipHandler) CreateMembershipHandler(c *gin.Context) {
+	ctx := c.Request.Context()
+	var payload CreateMembershipPayload
+
+	if err := c.ShouldBindJSON(&payload); err != nil {
+		h.services.LogErrors.BadRequestResponse(c, err)
+		return
+	}
+
+	membership, err := payload.toMembership()
+	if err != nil {
+		h.services.LogErrors.BadRequestResponse(c, err)
+		return
+	}
+
+	err = h.services.MembershipServices.CreateMembershipType(ctx, membership)
+	if err != nil {
+		switch err {
+		case shared_errors.ErrConflict:
+			h.services.LogErrors.ConflictResponse(c, err)
+		default:
+			h.services.LogErrors.InternalServerError(c, err)
+		}
+		return
+	}
+
+	c.JSON(http.StatusCreated, membership)
+}
+
+// @Summary		Update a membership type
+// @Description	Updates an existing membership type’s details.
+// @Tags			Memberships
+// @Accept			json
+// @Produce		json
+// @Security		ApiKeyAuth
+// @Param			id			path		string								true	"Membership Type UUID"
+// @Param			membership	body		UpdateMembershipPayload				true	"Membership update payload"
+// @Success		200			{object}	membershipsdomain.MembershipType	"Membership type updated successfully"
+// @Failure		400			{object}	object{error=string}				"error: Bad Request - Invalid ID or payload"
+// @Failure		404			{object}	object{error=string}				"error: Not Found - Membership type not found"
+// @Failure		500			{object}	object{error=string}				"error: Internal Server Error"
+// @Router			/memberships/types/{id} [put]
+func (h *MembershipHandler) UpdateMembershipHandler(c *gin.Context) {
+	ctx := c.Request.Context()
+	var payload UpdateMembershipPayload
+
+	membershipID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		h.services.LogErrors.BadRequestResponse(c, err)
+		return
+	}
+
+	if err := c.ShouldBindJSON(&payload); err != nil {
+		h.services.LogErrors.BadRequestResponse(c, err)
+		return
+	}
+
+	membership, err := payload.toMembership()
+	if err != nil {
+		h.services.LogErrors.BadRequestResponse(c, err)
+		return
+	}
+
+	membership.MembershipTypeID = membershipID
+
+	err = h.services.MembershipServices.UpdateMembershipType(ctx, membership)
+	if err != nil {
+		switch err {
+		case shared_errors.ErrNotFound:
+			h.services.LogErrors.NotFoundResponse(c)
+		default:
+			h.services.LogErrors.InternalServerError(c, err)
+		}
+		return
+	}
+
+	c.JSON(http.StatusOK, membership)
+}
+
+// @Summary		Delete a membership type
+// @Description	Soft deletes a membership type from the system (sets inactive).
+// @Tags			Memberships
+// @Produce		json
+// @Security		ApiKeyAuth
+// @Param			id	path		string					true	"Membership Type UUID"
+// @Success		204	{object}	nil						"No Content"
+// @Failure		400	{object}	object{error=string}	"error: Bad Request - Invalid ID"
+// @Failure		404	{object}	object{error=string}	"error: Not Found - Membership type not found"
+// @Failure		500	{object}	object{error=string}	"error: Internal Server Error"
+// @Router			/memberships/types/{id} [delete]
+func (h *MembershipHandler) DeleteMembershipHandler(c *gin.Context) {
+	ctx := c.Request.Context()
+	membershipID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		h.services.LogErrors.BadRequestResponse(c, err)
+		return
+	}
+
+	err = h.services.MembershipServices.DeleteMembershipType(ctx, membershipID)
+	if err != nil {
+		switch err {
+		case shared_errors.ErrNotFound:
+			h.services.LogErrors.NotFoundResponse(c)
+		default:
+			h.services.LogErrors.InternalServerError(c, err)
+		}
+		return
+	}
+
+	c.JSON(http.StatusNoContent, nil)
+}
+
+// @Summary		Get membership type by ID
+// @Description	Retrieves a single membership type by its UUID.
+// @Tags			Memberships
+// @Produce		json
+// @Security		ApiKeyAuth
+// @Param			id	path		string	true	"Membership Type UUID"
+// @Success		200	{object}	object{data=MembershipResponse}
+// @Failure		400	{object}	object{error=string}	"error: Bad Request - Invalid ID"
+// @Failure		404	{object}	object{error=string}	"error: Not Found - Membership type not found"
+// @Failure		500	{object}	object{error=string}	"error: Internal Server Error"
+// @Router			/memberships/types/{id} [get]
+func (h *MembershipHandler) GetMembershipByIDHandler(c *gin.Context) {
+	ctx := c.Request.Context()
+	membershipID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		h.services.LogErrors.BadRequestResponse(c, err)
+		return
+	}
+
+	membership, err := h.services.MembershipServices.GetMembershipTypeByID(ctx, membershipID)
+	if err != nil {
+		switch err {
+		case shared_errors.ErrNotFound:
+			h.services.LogErrors.NotFoundResponse(c)
+		default:
+			h.services.LogErrors.InternalServerError(c, err)
+		}
+		return
+	}
+
+	resp := &MembershipResponse{
+		MembershipTypeID: membership.MembershipTypeID,
+		Name:             membership.Name,
+		Description:      membership.Description,
+		DurationDays:     membership.DurationDays,
+		Price:            membership.Price,
+		IsActive:         membership.IsActive,
+	}
+	c.JSON(http.StatusOK, gin.H{"data": resp})
+}
+
+// @Summary		List all membership types
+// @Description	Retrieves a list of all membership types.
+// @Tags			Memberships
+// @Produce		json
+// @Security		ApiKeyAuth
+// @Success		200	{object}	object{data=[]MembershipResponse}
+// @Failure		500	{object}	object{error=string}	"error: Internal Server Error"
+// @Router			/memberships/types [get]
+func (h *MembershipHandler) GetMembershipsHandler(c *gin.Context) {
+	ctx := c.Request.Context()
+	memberships, err := h.services.MembershipServices.GetMembershipTypes(ctx)
+	if err != nil {
+		h.services.LogErrors.InternalServerError(c, err)
+		return
+	}
+
+	resp := make([]*MembershipResponse, 0, len(memberships))
+	for _, m := range memberships {
+		resp = append(resp, &MembershipResponse{
+			MembershipTypeID: m.MembershipTypeID,
+			Name:             m.Name,
+			Description:      m.Description,
+			DurationDays:     m.DurationDays,
+			Price:            m.Price,
+			IsActive:         m.IsActive,
+		})
+	}
+
+	c.JSON(http.StatusOK, gin.H{"data": resp})
+}

--- a/internal/modules/memberships/handlers/payload.go
+++ b/internal/modules/memberships/handlers/payload.go
@@ -1,0 +1,61 @@
+package membershipshandlers
+
+import (
+	"github.com/google/uuid"
+	membershipsdomain "github.com/vitalfit/api/internal/modules/memberships/domain"
+)
+
+// CreateMembershipPayload define la estructura esperada en el body
+// del request para crear un nuevo tipo de membresía.
+type CreateMembershipPayload struct {
+	Name         string  `json:"name" binding:"required"`
+	Description  string  `json:"description"`
+	DurationDays int     `json:"duration_days" binding:"required"`
+	Price        float64 `json:"price" binding:"required"`
+	IsActive     bool    `json:"is_active"`
+}
+
+// UpdateMembershipPayload define la estructura esperada para actualizar
+// un tipo de membresía existente.
+type UpdateMembershipPayload struct {
+	Name         string  `json:"name"`
+	Description  string  `json:"description"`
+	DurationDays int     `json:"duration_days"`
+	Price        float64 `json:"price"`
+	IsActive     bool    `json:"is_active"`
+}
+
+// Convierte el payload de creación en una entidad de dominio.
+func (p *CreateMembershipPayload) toMembership() (*membershipsdomain.MembershipType, error) {
+	m := &membershipsdomain.MembershipType{
+		Name:         p.Name,
+		Description:  p.Description,
+		DurationDays: p.DurationDays,
+		Price:        p.Price,
+		IsActive:     p.IsActive,
+	}
+	return m, nil
+}
+
+// Convierte el payload de actualización en una entidad de dominio.
+func (p *UpdateMembershipPayload) toMembership() (*membershipsdomain.MembershipType, error) {
+	m := &membershipsdomain.MembershipType{
+		Name:         p.Name,
+		Description:  p.Description,
+		DurationDays: p.DurationDays,
+		Price:        p.Price,
+		IsActive:     p.IsActive,
+	}
+	return m, nil
+}
+
+// MembershipResponse representa la estructura del tipo de membresía
+// devuelta al cliente en las respuestas de lectura.
+type MembershipResponse struct {
+	MembershipTypeID uuid.UUID `json:"membership_type_id"`
+	Name             string    `json:"name"`
+	Description      string    `json:"description"`
+	DurationDays     int       `json:"duration_days"`
+	Price            float64   `json:"price"`
+	IsActive         bool      `json:"is_active"`
+}

--- a/internal/modules/memberships/handlers/routes.go
+++ b/internal/modules/memberships/handlers/routes.go
@@ -11,15 +11,24 @@ type MembershipsHandlerInterface interface {
 }
 
 type MembershipHandler struct {
-	service appservices.Services
+	services appservices.Services
 }
 
-func NewMembershipHandler(service appservices.Services) *MembershipHandler {
+func NewMembershipHandler(services appservices.Services) *MembershipHandler {
 	return &MembershipHandler{
-		service: service,
+		services: services,
 	}
 }
 
 func (r *MembershipHandler) MembershipRoutes(rg *gin.RouterGroup, m *auth.AuthMiddleware) {
+	membershipPlansGroup := rg.Group("/membership-plans")
+	{
+		membershipPlansGroup.Use(m.AuthJwtTokenMiddleware())
 
+		membershipPlansGroup.POST("", m.RBACPermission("memberships:create"), r.CreateMembershipHandler)
+		membershipPlansGroup.GET("", m.RBACPermission("memberships:list"), r.GetMembershipsHandler)
+		membershipPlansGroup.GET("/:id", m.RBACPermission("memberships:get"), r.GetMembershipByIDHandler)
+		membershipPlansGroup.PUT("/:id", m.RBACPermission("memberships:update"), r.UpdateMembershipHandler)
+		membershipPlansGroup.DELETE("/:id", m.RBACPermission("memberships:delete"), r.DeleteMembershipHandler)
+	}
 }

--- a/internal/modules/memberships/repository/membership_repository.go
+++ b/internal/modules/memberships/repository/membership_repository.go
@@ -1,6 +1,16 @@
 package membershipsrepository
 
-import "gorm.io/gorm"
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
+	membershipsdomain "github.com/vitalfit/api/internal/modules/memberships/domain"
+	shared_errors "github.com/vitalfit/api/internal/shared/errors"
+	"gorm.io/gorm"
+)
 
 type MembershipStore struct {
 	db *gorm.DB
@@ -10,4 +20,95 @@ func NewMembershipStore(db *gorm.DB) *MembershipStore {
 	return &MembershipStore{
 		db: db,
 	}
+}
+
+// CreateMembershipType crea un nuevo tipo de membresía en la base de datos.
+func (s *MembershipStore) CreateMembershipType(ctx context.Context, membership *membershipsdomain.MembershipType) error {
+	err := s.db.WithContext(ctx).Create(membership).Error
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) {
+			if pgErr.Code == "23505" { // unique_violation
+				return shared_errors.ErrConflict
+			}
+		}
+		return err
+	}
+	return nil
+}
+
+// CreateMembershipTypeTX permite crear un tipo de membresía dentro de una transacción activa.
+func (s *MembershipStore) CreateMembershipTypeTX(ctx context.Context, tx *gorm.DB, membership *membershipsdomain.MembershipType) error {
+	err := tx.WithContext(ctx).Create(membership).Error
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) {
+			if pgErr.Code == "23505" {
+				return shared_errors.ErrConflict
+			}
+		}
+		return err
+	}
+	return nil
+}
+
+// UpdateMembershipType actualiza los datos de un tipo de membresía existente.
+func (s *MembershipStore) UpdateMembershipType(ctx context.Context, membership *membershipsdomain.MembershipType) error {
+	err := s.db.WithContext(ctx).Save(membership).Error
+	if err != nil {
+		switch err {
+		case gorm.ErrRecordNotFound:
+			return shared_errors.ErrNotFound
+		default:
+			return err
+		}
+	}
+	return nil
+}
+
+// DeleteMembershipType realiza una eliminación lógica del tipo de membresía (soft delete).
+func (s *MembershipStore) DeleteMembershipType(ctx context.Context, id uuid.UUID) error {
+	var membership membershipsdomain.MembershipType
+	result := s.db.WithContext(ctx).First(&membership, "membership_type_id = ?", id)
+	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+		return shared_errors.ErrNotFound
+	}
+
+	now := time.Now()
+	membership.IsActive = false
+	membership.DeletedAt = &now
+
+	if err := s.db.WithContext(ctx).Save(&membership).Error; err != nil {
+		return err
+	}
+	return nil
+}
+
+// GetMembershipTypeByID obtiene un tipo de membresía por su UUID.
+func (s *MembershipStore) GetMembershipTypeByID(ctx context.Context, id uuid.UUID) (*membershipsdomain.MembershipType, error) {
+	membership := &membershipsdomain.MembershipType{}
+	err := s.db.WithContext(ctx).
+		Where("membership_type_id = ? AND deleted_at IS NULL", id).
+		First(membership).Error
+	if err != nil {
+		switch err {
+		case gorm.ErrRecordNotFound:
+			return nil, shared_errors.ErrNotFound
+		default:
+			return nil, err
+		}
+	}
+	return membership, nil
+}
+
+// GetMembershipTypes devuelve todos los tipos de membresía activos.
+func (s *MembershipStore) GetMembershipTypes(ctx context.Context) ([]*membershipsdomain.MembershipType, error) {
+	memberships := []*membershipsdomain.MembershipType{}
+	err := s.db.WithContext(ctx).
+		Where("deleted_at IS NULL").
+		Find(&memberships).Error
+	if err != nil {
+		return nil, err
+	}
+	return memberships, nil
 }

--- a/internal/modules/memberships/service/membership_services.go
+++ b/internal/modules/memberships/service/membership_services.go
@@ -1,13 +1,66 @@
 package membershipsservice
 
-import "github.com/vitalfit/api/internal/store"
+import (
+	"context"
 
+	"github.com/google/uuid"
+	membershipsdomain "github.com/vitalfit/api/internal/modules/memberships/domain"
+	"github.com/vitalfit/api/internal/store"
+)
+
+// MembershipService implementa la lógica de negocio para los tipos de membresía.
 type MembershipService struct {
 	store store.Storage
 }
 
+// NewMembershipService crea una nueva instancia del servicio de membresías.
 func NewMembershipService(store store.Storage) *MembershipService {
 	return &MembershipService{
 		store: store,
 	}
+}
+
+// CreateMembershipType crea un nuevo tipo de membresía.
+func (s *MembershipService) CreateMembershipType(ctx context.Context, membership *membershipsdomain.MembershipType) error {
+	err := s.store.Membership.CreateMembershipType(ctx, membership)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// UpdateMembershipType actualiza un tipo de membresía existente.
+func (s *MembershipService) UpdateMembershipType(ctx context.Context, membership *membershipsdomain.MembershipType) error {
+	err := s.store.Membership.UpdateMembershipType(ctx, membership)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// DeleteMembershipType realiza una eliminación lógica (soft delete) del tipo de membresía.
+func (s *MembershipService) DeleteMembershipType(ctx context.Context, id uuid.UUID) error {
+	err := s.store.Membership.DeleteMembershipType(ctx, id)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// GetMembershipTypeByID obtiene un tipo de membresía por su ID.
+func (s *MembershipService) GetMembershipTypeByID(ctx context.Context, id uuid.UUID) (*membershipsdomain.MembershipType, error) {
+	membership, err := s.store.Membership.GetMembershipTypeByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	return membership, nil
+}
+
+// GetMembershipTypes devuelve todos los tipos de membresía activos.
+func (s *MembershipService) GetMembershipTypes(ctx context.Context) ([]*membershipsdomain.MembershipType, error) {
+	memberships, err := s.store.Membership.GetMembershipTypes(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return memberships, nil
 }


### PR DESCRIPTION
THIS PROJECT IS IN MAINTENANCE MODE. We accept pull-requests for Bug Fixes **ONLY**. NO NEW FEATURES ACCEPTED!
<!--- Provide a general summary of your changes in the Title above -->

**## Description**
This pull request introduces the full CRUD implementation for the **Membership Plans** module, allowing Super Administrators to manage membership types (monthly, quarterly, annual, corporate).  
It includes endpoints for:
- Creating a new membership plan (`POST /v1/membership-plans`)
- Listing all plans (`GET /v1/membership-plans`)
- Retrieving a plan by ID (`GET /v1/membership-plans/:id`)
- Updating an existing plan (`PUT /v1/membership-plans/:id`)
- Deactivating or deleting a plan (`DELETE /v1/membership-plans/:id`)

Each endpoint follows the project’s architecture conventions (domain, repository, service, handler) and integrates with the RBAC permission system.

**## Related Issue**
HU: **HU-AW44RF (RF-34)** — Manage different types of memberships for client variety.  
_No additional open issue was linked._

**## Motivation and Context**
This change implements the functionality requested in RF-34 to enable Super Administrators to create and manage membership plan templates.  
It ensures consistency with other modules (e.g., Marketing, Branches) and maintains proper RBAC protection and Swagger documentation for all endpoints.

**## How Has This Been Tested?**
- Verified endpoint responses using Postman with valid JWT tokens.
- Successfully tested the following:
  - `POST` creates a plan and persists it in `membership_types`.
  - `GET` (all and by ID) returns the expected data.
  - `PUT` updates existing plans.
  - `DELETE` properly deactivates or removes the record.
- Confirmed data integrity directly in PostgreSQL.
- Swagger documentation reviewed and accessible at `/v1/swagger/index.html`.

## Screenshots (if appropriate):
N/A
