### PR TITLE
feat(packages): Implement CRUD for Packages

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -4720,6 +4720,307 @@ const docTemplate = `{
                 }
             }
         },
+        "/packages": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Retrieves a paginated list of all available packages, with optional searching by name.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Packages"
+                ],
+                "summary": "List all packages",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "default": 10,
+                        "description": "Number of results per page",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 1,
+                        "description": "Page number for pagination",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "asc",
+                            "desc"
+                        ],
+                        "type": "string",
+                        "default": "desc",
+                        "description": "Sort order (asc/desc)",
+                        "name": "sort",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search term for package name",
+                        "name": "search",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "A paginated list of packages",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "$ref": "#/definitions/comboshandler.PackageResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request: Invalid query parameters",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Adds a new package with its items to the system.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Packages"
+                ],
+                "summary": "Create a new package",
+                "parameters": [
+                    {
+                        "description": "Package creation payload",
+                        "name": "package",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/comboshandler.CreatePackageRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Package created successfully",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request: Invalid payload",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/packages/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Retrieves detailed information about a specific package by its UUID, including its items.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Packages"
+                ],
+                "summary": "Get package by ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Package UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Package details",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "$ref": "#/definitions/comboshandler.PackageResponseByID"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request: Invalid UUID format",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found: Package not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Updates an existing package's information, including its items.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Packages"
+                ],
+                "summary": "Update a package",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Package UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Payload with fields to update",
+                        "name": "package",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/comboshandler.CreatePackageRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Package updated successfully"
+                    },
+                    "400": {
+                        "description": "Bad Request: Invalid UUID or payload",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found: Package not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Deletes a specific package by its UUID.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Packages"
+                ],
+                "summary": "Delete a package",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Package UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Package deleted successfully"
+                    },
+                    "400": {
+                        "description": "Bad Request: Invalid UUID format",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found: Package not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/public/branches-map": {
             "get": {
                 "description": "Retrieves a list of public branches with minimal information for map display.",
@@ -6710,6 +7011,138 @@ const docTemplate = `{
                 "tax_id": {
                     "type": "string",
                     "minLength": 5
+                }
+            }
+        },
+        "comboshandler.CreatePackageItemRequest": {
+            "type": "object",
+            "required": [
+                "serviceId",
+                "sessionsIncluded"
+            ],
+            "properties": {
+                "serviceId": {
+                    "type": "string"
+                },
+                "sessionsIncluded": {
+                    "type": "integer",
+                    "minimum": 1
+                }
+            }
+        },
+        "comboshandler.CreatePackageRequest": {
+            "type": "object",
+            "required": [
+                "name",
+                "packageItems",
+                "price"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "endAt": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "packageItems": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/comboshandler.CreatePackageItemRequest"
+                    }
+                },
+                "price": {
+                    "type": "number"
+                },
+                "startAt": {
+                    "type": "string"
+                }
+            }
+        },
+        "comboshandler.PackageItemResponse": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "serviceId": {
+                    "type": "string"
+                },
+                "sessionsIncluded": {
+                    "type": "integer"
+                }
+            }
+        },
+        "comboshandler.PackageResponse": {
+            "type": "object",
+            "properties": {
+                "createdAt": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "endAt": {
+                    "type": "string"
+                },
+                "isActive": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "packageId": {
+                    "type": "string"
+                },
+                "price": {
+                    "type": "number"
+                },
+                "startAt": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
+        "comboshandler.PackageResponseByID": {
+            "type": "object",
+            "properties": {
+                "createdAt": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "endAt": {
+                    "type": "string"
+                },
+                "isActive": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "packageId": {
+                    "type": "string"
+                },
+                "packageItems": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/comboshandler.PackageItemResponse"
+                    }
+                },
+                "price": {
+                    "type": "number"
+                },
+                "startAt": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -4712,6 +4712,307 @@
                 }
             }
         },
+        "/packages": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Retrieves a paginated list of all available packages, with optional searching by name.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Packages"
+                ],
+                "summary": "List all packages",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "default": 10,
+                        "description": "Number of results per page",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 1,
+                        "description": "Page number for pagination",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "asc",
+                            "desc"
+                        ],
+                        "type": "string",
+                        "default": "desc",
+                        "description": "Sort order (asc/desc)",
+                        "name": "sort",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search term for package name",
+                        "name": "search",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "A paginated list of packages",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "$ref": "#/definitions/comboshandler.PackageResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request: Invalid query parameters",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Adds a new package with its items to the system.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Packages"
+                ],
+                "summary": "Create a new package",
+                "parameters": [
+                    {
+                        "description": "Package creation payload",
+                        "name": "package",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/comboshandler.CreatePackageRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Package created successfully",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request: Invalid payload",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/packages/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Retrieves detailed information about a specific package by its UUID, including its items.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Packages"
+                ],
+                "summary": "Get package by ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Package UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Package details",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "$ref": "#/definitions/comboshandler.PackageResponseByID"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request: Invalid UUID format",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found: Package not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Updates an existing package's information, including its items.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Packages"
+                ],
+                "summary": "Update a package",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Package UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Payload with fields to update",
+                        "name": "package",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/comboshandler.CreatePackageRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Package updated successfully"
+                    },
+                    "400": {
+                        "description": "Bad Request: Invalid UUID or payload",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found: Package not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Deletes a specific package by its UUID.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Packages"
+                ],
+                "summary": "Delete a package",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Package UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Package deleted successfully"
+                    },
+                    "400": {
+                        "description": "Bad Request: Invalid UUID format",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found: Package not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/public/branches-map": {
             "get": {
                 "description": "Retrieves a list of public branches with minimal information for map display.",
@@ -6702,6 +7003,138 @@
                 "tax_id": {
                     "type": "string",
                     "minLength": 5
+                }
+            }
+        },
+        "comboshandler.CreatePackageItemRequest": {
+            "type": "object",
+            "required": [
+                "serviceId",
+                "sessionsIncluded"
+            ],
+            "properties": {
+                "serviceId": {
+                    "type": "string"
+                },
+                "sessionsIncluded": {
+                    "type": "integer",
+                    "minimum": 1
+                }
+            }
+        },
+        "comboshandler.CreatePackageRequest": {
+            "type": "object",
+            "required": [
+                "name",
+                "packageItems",
+                "price"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "endAt": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "packageItems": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/comboshandler.CreatePackageItemRequest"
+                    }
+                },
+                "price": {
+                    "type": "number"
+                },
+                "startAt": {
+                    "type": "string"
+                }
+            }
+        },
+        "comboshandler.PackageItemResponse": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "serviceId": {
+                    "type": "string"
+                },
+                "sessionsIncluded": {
+                    "type": "integer"
+                }
+            }
+        },
+        "comboshandler.PackageResponse": {
+            "type": "object",
+            "properties": {
+                "createdAt": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "endAt": {
+                    "type": "string"
+                },
+                "isActive": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "packageId": {
+                    "type": "string"
+                },
+                "price": {
+                    "type": "number"
+                },
+                "startAt": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
+        "comboshandler.PackageResponseByID": {
+            "type": "object",
+            "properties": {
+                "createdAt": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "endAt": {
+                    "type": "string"
+                },
+                "isActive": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "packageId": {
+                    "type": "string"
+                },
+                "packageItems": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/comboshandler.PackageItemResponse"
+                    }
+                },
+                "price": {
+                    "type": "number"
+                },
+                "startAt": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -656,6 +656,94 @@ definitions:
     - state
     - tax_id
     type: object
+  comboshandler.CreatePackageItemRequest:
+    properties:
+      serviceId:
+        type: string
+      sessionsIncluded:
+        minimum: 1
+        type: integer
+    required:
+    - serviceId
+    - sessionsIncluded
+    type: object
+  comboshandler.CreatePackageRequest:
+    properties:
+      description:
+        type: string
+      endAt:
+        type: string
+      name:
+        type: string
+      packageItems:
+        items:
+          $ref: '#/definitions/comboshandler.CreatePackageItemRequest'
+        minItems: 1
+        type: array
+      price:
+        type: number
+      startAt:
+        type: string
+    required:
+    - name
+    - packageItems
+    - price
+    type: object
+  comboshandler.PackageItemResponse:
+    properties:
+      name:
+        type: string
+      serviceId:
+        type: string
+      sessionsIncluded:
+        type: integer
+    type: object
+  comboshandler.PackageResponse:
+    properties:
+      createdAt:
+        type: string
+      description:
+        type: string
+      endAt:
+        type: string
+      isActive:
+        type: boolean
+      name:
+        type: string
+      packageId:
+        type: string
+      price:
+        type: number
+      startAt:
+        type: string
+      updatedAt:
+        type: string
+    type: object
+  comboshandler.PackageResponseByID:
+    properties:
+      createdAt:
+        type: string
+      description:
+        type: string
+      endAt:
+        type: string
+      isActive:
+        type: boolean
+      name:
+        type: string
+      packageId:
+        type: string
+      packageItems:
+        items:
+          $ref: '#/definitions/comboshandler.PackageItemResponse'
+        type: array
+      price:
+        type: number
+      startAt:
+        type: string
+      updatedAt:
+        type: string
+    type: object
   instructordomain.InstructorSummary:
     properties:
       actives:
@@ -4503,6 +4591,206 @@ paths:
       summary: Get a summary of membership types
       tags:
       - Memberships
+  /packages:
+    get:
+      description: Retrieves a paginated list of all available packages, with optional
+        searching by name.
+      parameters:
+      - default: 10
+        description: Number of results per page
+        in: query
+        name: limit
+        type: integer
+      - default: 1
+        description: Page number for pagination
+        in: query
+        name: page
+        type: integer
+      - default: desc
+        description: Sort order (asc/desc)
+        enum:
+        - asc
+        - desc
+        in: query
+        name: sort
+        type: string
+      - description: Search term for package name
+        in: query
+        name: search
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: A paginated list of packages
+          schema:
+            properties:
+              data:
+                $ref: '#/definitions/comboshandler.PackageResponse'
+            type: object
+        "400":
+          description: 'Bad Request: Invalid query parameters'
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal server error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - ApiKeyAuth: []
+      summary: List all packages
+      tags:
+      - Packages
+    post:
+      consumes:
+      - application/json
+      description: Adds a new package with its items to the system.
+      parameters:
+      - description: Package creation payload
+        in: body
+        name: package
+        required: true
+        schema:
+          $ref: '#/definitions/comboshandler.CreatePackageRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Package created successfully
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: 'Bad Request: Invalid payload'
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - ApiKeyAuth: []
+      summary: Create a new package
+      tags:
+      - Packages
+  /packages/{id}:
+    delete:
+      description: Deletes a specific package by its UUID.
+      parameters:
+      - description: Package UUID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: Package deleted successfully
+        "400":
+          description: 'Bad Request: Invalid UUID format'
+          schema:
+            additionalProperties: true
+            type: object
+        "404":
+          description: 'Not Found: Package not found'
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - ApiKeyAuth: []
+      summary: Delete a package
+      tags:
+      - Packages
+    get:
+      description: Retrieves detailed information about a specific package by its
+        UUID, including its items.
+      parameters:
+      - description: Package UUID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Package details
+          schema:
+            properties:
+              data:
+                $ref: '#/definitions/comboshandler.PackageResponseByID'
+            type: object
+        "400":
+          description: 'Bad Request: Invalid UUID format'
+          schema:
+            additionalProperties: true
+            type: object
+        "404":
+          description: 'Not Found: Package not found'
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - ApiKeyAuth: []
+      summary: Get package by ID
+      tags:
+      - Packages
+    put:
+      consumes:
+      - application/json
+      description: Updates an existing package's information, including its items.
+      parameters:
+      - description: Package UUID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Payload with fields to update
+        in: body
+        name: package
+        required: true
+        schema:
+          $ref: '#/definitions/comboshandler.CreatePackageRequest'
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: Package updated successfully
+        "400":
+          description: 'Bad Request: Invalid UUID or payload'
+          schema:
+            additionalProperties: true
+            type: object
+        "404":
+          description: 'Not Found: Package not found'
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - ApiKeyAuth: []
+      summary: Update a package
+      tags:
+      - Packages
   /public/branches-map:
     get:
       description: Retrieves a list of public branches with minimal information for

--- a/internal/app/application.go
+++ b/internal/app/application.go
@@ -81,6 +81,9 @@ func (app *application) Mount() http.Handler {
 		//schedule routes
 		app.Handlers.ScheduleHandlers.ScheduleRoutes(v1, m)
 
+		//combos routes
+		app.Handlers.CombosHandlers.CombosRoutes(v1, m)
+
 		v1.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
 
 	}

--- a/internal/app/handlers/handlers.go
+++ b/internal/app/handlers/handlers.go
@@ -5,6 +5,7 @@ import (
 	authhandlers "github.com/vitalfit/api/internal/modules/auth/handlers"
 	billinghandlers "github.com/vitalfit/api/internal/modules/billing/handlers"
 	branchhandlers "github.com/vitalfit/api/internal/modules/branches/handlers"
+	comboshandler "github.com/vitalfit/api/internal/modules/combos/handler"
 	instructorhandler "github.com/vitalfit/api/internal/modules/instructor/handler"
 	inventoryhandlers "github.com/vitalfit/api/internal/modules/inventory/handlers"
 	marketinghandlers "github.com/vitalfit/api/internal/modules/marketing/handlers"
@@ -23,6 +24,7 @@ type Handlers struct {
 	MembershipHandlers membershipshandlers.MembershipsHandlerInterface
 	BillingHandlers    billinghandlers.BillingHandlersInterface
 	ScheduleHandlers   schedulehandlers.ScheduleHandlersInterface
+	CombosHandlers     comboshandler.CombosHandlerInterface
 }
 
 func NewAppHandlers(services appservices.Services) Handlers {
@@ -36,5 +38,6 @@ func NewAppHandlers(services appservices.Services) Handlers {
 		MembershipHandlers: membershipshandlers.NewMembershipHandler(services),
 		BillingHandlers:    billinghandlers.NewBillingHandlers(services),
 		ScheduleHandlers:   schedulehandlers.NewScheduleHandlers(services),
+		CombosHandlers:     comboshandler.NewCombosHandler(services),
 	}
 }

--- a/internal/app/services/services.go
+++ b/internal/app/services/services.go
@@ -8,6 +8,8 @@ import (
 	billingservice "github.com/vitalfit/api/internal/modules/billing/service"
 	branchdomain "github.com/vitalfit/api/internal/modules/branches/domain"
 	branchservices "github.com/vitalfit/api/internal/modules/branches/services"
+	combosdomain "github.com/vitalfit/api/internal/modules/combos/domain"
+	combosservices "github.com/vitalfit/api/internal/modules/combos/services"
 	instructordomain "github.com/vitalfit/api/internal/modules/instructor/domain"
 	instructorservices "github.com/vitalfit/api/internal/modules/instructor/services"
 	inventorydomain "github.com/vitalfit/api/internal/modules/inventory/domain"
@@ -40,6 +42,7 @@ type Services struct {
 	MembershipServices membershipsdomain.MembershipsServiceInterface
 	BillingServices    billingdomain.BillingServiceInterface
 	ScheduleServices   scheduledomain.ScheduleServiceInterface
+	CombosServices     combosdomain.CombosServicesInterface
 	logs.LogErrors
 	Logger *zap.SugaredLogger
 }
@@ -58,6 +61,7 @@ func NewServices(store store.Storage, logger *zap.SugaredLogger, cfg config.Conf
 		MembershipServices: membershipsservice.NewMembershipService(store),
 		BillingServices:    billingservice.NewBillingService(store),
 		ScheduleServices:   scheduleservice.NewScheduleService(store),
+		CombosServices:     combosservices.NewCombosServices(store),
 		LogErrors:          logs.NewLogErrors(logger),
 		Logger:             logger,
 	}

--- a/internal/migrate/migrations/000023_create_package.down.sql
+++ b/internal/migrate/migrations/000023_create_package.down.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS package_items;
+
+DROP TABLE IF EXISTS packages;

--- a/internal/migrate/migrations/000023_create_package.up.sql
+++ b/internal/migrate/migrations/000023_create_package.up.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS packages (
+    package_id UUID PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    price DECIMAL(10, 2) NOT NULL,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    start_at TIMESTAMPTZ,
+    end_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ,
+    deleted_at TIMESTAMPTZ
+);
+
+CREATE TABLE IF NOT EXISTS package_items (
+    package_id UUID NOT NULL REFERENCES packages(package_id) ON DELETE CASCADE,
+    service_id UUID NOT NULL REFERENCES services(service_id) ON DELETE CASCADE,
+    sessions_included INT NOT NULL DEFAULT 10,
+    
+    PRIMARY KEY (package_id, service_id)
+);

--- a/internal/migrate/migrations/000023_create_package.up.sql
+++ b/internal/migrate/migrations/000023_create_package.up.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS packages (
-    package_id UUID PRIMARY KEY,
+    package_id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     name VARCHAR(255) NOT NULL,
     description TEXT,
     price DECIMAL(10, 2) NOT NULL,

--- a/internal/modules/combos/domain/packages.go
+++ b/internal/modules/combos/domain/packages.go
@@ -1,1 +1,41 @@
 package combosdomain
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	productsdomain "github.com/vitalfit/api/internal/modules/products/domain"
+	"gorm.io/gorm"
+)
+
+type Package struct {
+	PackageID   uuid.UUID  `gorm:"type:uuid;primary_key;default:gen_random_uuid()"`
+	Name        string     `gorm:"type:varchar(255);not null"`
+	Description string     `gorm:"type:text"`
+	Price       float64    `gorm:"type:decimal(10,2);not null"`
+	IsActive    bool       `gorm:"not null;default:true"`
+	StartAt     *time.Time `gorm:"type:timestamptz"`
+	EndAt       *time.Time `gorm:"type:timestamptz"`
+	CreatedAt   time.Time  `gorm:"default:now()"`
+	UpdatedAt   time.Time
+	DeletedAt   gorm.DeletedAt `gorm:"index"`
+
+	PackageItems []PackageItem `gorm:"foreignKey:PackageID;constraint:OnDelete:CASCADE"`
+}
+
+func (Package) TableName() string {
+	return "packages"
+}
+
+type PackageItem struct {
+	PackageID        uuid.UUID `gorm:"type:uuid;primary_key"`
+	ServiceID        uuid.UUID `gorm:"type:uuid;primary_key"`
+	SessionsIncluded int       `gorm:"not null;default:10"`
+
+	Package Package                `gorm:"foreignKey:PackageID"`
+	Service productsdomain.Service `gorm:"foreignKey:ServiceID"`
+}
+
+func (PackageItem) TableName() string {
+	return "package_items"
+}

--- a/internal/modules/combos/domain/packages.go
+++ b/internal/modules/combos/domain/packages.go
@@ -1,0 +1,1 @@
+package combosdomain

--- a/internal/modules/combos/domain/repository.go
+++ b/internal/modules/combos/domain/repository.go
@@ -1,4 +1,17 @@
 package combosdomain
 
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/vitalfit/api/pkg/pagination"
+)
+
 type CombosRepository interface {
+	CreatePackage(ctx context.Context, pkg *Package) error
+	GetPackages(ctx context.Context, fq pagination.PaginatedFeedQuery) ([]*Package, error)
+	GetPackagesTotal(ctx context.Context, fq pagination.PaginatedFeedQuery) (int64, error)
+	GetPackageByID(ctx context.Context, packageID uuid.UUID) (*Package, error)
+	UpdatePackage(ctx context.Context, pkg *Package) error
+	DeletePackage(ctx context.Context, packageID uuid.UUID) error
 }

--- a/internal/modules/combos/domain/repository.go
+++ b/internal/modules/combos/domain/repository.go
@@ -1,0 +1,4 @@
+package combosdomain
+
+type CombosRepository interface {
+}

--- a/internal/modules/combos/domain/services.go
+++ b/internal/modules/combos/domain/services.go
@@ -1,4 +1,17 @@
 package combosdomain
 
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/vitalfit/api/pkg/pagination"
+)
+
 type CombosServicesInterface interface {
+	CreatePackage(ctx context.Context, pkg *Package) error
+	GetPackages(ctx context.Context, fq pagination.PaginatedFeedQuery) ([]*Package, error)
+	GetPackagesTotal(ctx context.Context, fq pagination.PaginatedFeedQuery) (int64, error)
+	GetPackageByID(ctx context.Context, packageID uuid.UUID) (*Package, error)
+	UpdatePackage(ctx context.Context, pkg *Package) error
+	DeletePackage(ctx context.Context, packageID uuid.UUID) error
 }

--- a/internal/modules/combos/domain/services.go
+++ b/internal/modules/combos/domain/services.go
@@ -1,0 +1,4 @@
+package combosdomain
+
+type CombosServicesInterface interface {
+}

--- a/internal/modules/combos/handler/combos_handlers.go
+++ b/internal/modules/combos/handler/combos_handlers.go
@@ -1,0 +1,245 @@
+package comboshandler
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	shared_errors "github.com/vitalfit/api/internal/shared/errors"
+	"github.com/vitalfit/api/pkg/pagination"
+)
+
+// @Summary		Create a new package
+// @Description	Adds a new package with its items to the system.
+// @Tags			Packages
+// @Security		ApiKeyAuth
+// @Accept			json
+// @Produce		json
+// @Param			package	body		CreatePackageRequest	true	"Package creation payload"
+// @Success		201		{object}	map[string]interface{}	"Package created successfully"
+// @Failure		400		{object}	map[string]interface{}	"Bad Request: Invalid payload"
+// @Failure		500		{object}	map[string]interface{}	"Internal Server Error"
+// @Router			/packages [post]
+func (h *CombosHandler) CreatePackageHandler(c *gin.Context) {
+	ctx := c.Request.Context()
+	var payload CreatePackageRequest
+	if err := c.ShouldBindJSON(&payload); err != nil {
+		h.services.LogErrors.BadRequestResponse(c, err)
+		return
+	}
+	pkg, err := payload.ToPackage()
+	if err != nil {
+		h.services.LogErrors.BadRequestResponse(c, err)
+		return
+	}
+	err = h.services.CombosServices.CreatePackage(ctx, pkg)
+	if err != nil {
+		h.services.LogErrors.InternalServerError(c, err)
+		return
+	}
+	c.JSON(201, gin.H{"message": "Package created successfully"})
+
+}
+
+// @Summary		List all packages
+// @Description	Retrieves a paginated list of all available packages, with optional searching by name.
+// @Tags			Packages
+// @Security		ApiKeyAuth
+// @Produce		json
+// @Param			limit	query		int										false	"Number of results per page"	default(10)
+// @Param			page	query		int										false	"Page number for pagination"	default(1)
+// @Param			sort	query		string									false	"Sort order (asc/desc)"			enums(asc, desc)	default(desc)
+// @Param			search	query		string									false	"Search term for package name"
+// @Success		200		{object}	pagination.PaginatedResponseTotal[PackageResponse]	"A paginated list of packages"
+// @Failure		400		{object}	map[string]interface{}					"Bad Request: Invalid query parameters"
+// @Failure		500		{object}	map[string]interface{}					"Internal server error"
+// @Router			/packages [get]
+func (h *CombosHandler) GetPackageHandler(c *gin.Context) {
+	ctx := c.Request.Context()
+	fq := pagination.PaginatedFeedQuery{
+		Page:   1,
+		Limit:  10,
+		Search: "",
+	}
+	fq, err := fq.Parse(c.Request)
+	if err != nil {
+		h.services.LogErrors.BadRequestResponse(c, err)
+		return
+	}
+	nextURL := fmt.Sprintf("/packages?limit=%d&page=%d&sort=%s", fq.Limit, fq.Page+1, fq.Sort)
+	previousPage := fq.Page - 1
+	if previousPage <= 0 {
+		previousPage = 1
+	}
+	previousURL := fmt.Sprintf("/packages?limit=%d&page=%d&sort=%s", fq.Limit, previousPage, fq.Sort)
+
+	packages, err := h.services.CombosServices.GetPackages(ctx, fq)
+	if err != nil {
+		h.services.LogErrors.InternalServerError(c, err)
+		return
+	}
+
+	total, err := h.services.CombosServices.GetPackagesTotal(ctx, fq)
+	if err != nil {
+		h.services.LogErrors.InternalServerError(c, err)
+		return
+	}
+
+	data := make([]PackageResponse, len(packages))
+	for i, pkg := range packages {
+		data[i] = PackageResponse{
+			PackageID:   pkg.PackageID,
+			Name:        pkg.Name,
+			Description: pkg.Description,
+			Price:       pkg.Price,
+			IsActive:    pkg.IsActive,
+			StartAt:     pkg.StartAt,
+			EndAt:       pkg.EndAt,
+			CreatedAt:   pkg.CreatedAt,
+			UpdatedAt:   pkg.UpdatedAt,
+		}
+	}
+
+	resp := pagination.PaginatedResponseTotal[PackageResponse]{
+		Data:     data,
+		Next:     nextURL,
+		Previous: previousURL,
+		Count:    int64(len(packages)),
+		Total:    total,
+	}
+	c.JSON(200, gin.H{"data": resp})
+}
+
+// @Summary		Get package by ID
+// @Description	Retrieves detailed information about a specific package by its UUID, including its items.
+// @Tags			Packages
+// @Security		ApiKeyAuth
+// @Produce		json
+// @Param			id	path		string					true	"Package UUID"
+// @Success		200	{object}	object{data=PackageResponseByID}	"Package details"
+// @Failure		400	{object}	map[string]interface{}	"Bad Request: Invalid UUID format"
+// @Failure		404	{object}	map[string]interface{}	"Not Found: Package not found"
+// @Failure		500	{object}	map[string]interface{}	"Internal Server Error"
+// @Router			/packages/{id} [get]
+func (h *CombosHandler) GetPackageByIDHandler(c *gin.Context) {
+	ctx := c.Request.Context()
+	packageID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		h.services.LogErrors.BadRequestResponse(c, err)
+		return
+	}
+
+	pkg, err := h.services.CombosServices.GetPackageByID(ctx, packageID)
+	if err != nil {
+		switch err {
+		case shared_errors.ErrNotFound:
+			h.services.LogErrors.NotFoundResponse(c)
+		default:
+			h.services.LogErrors.InternalServerError(c, err)
+		}
+		return
+	}
+
+	packageItems := make([]PackageItemResponse, len(pkg.PackageItems))
+	for i, item := range pkg.PackageItems {
+		packageItems[i] = PackageItemResponse{
+			ServiceID:        item.ServiceID,
+			SessionsIncluded: item.SessionsIncluded,
+		}
+	}
+
+	resp := PackageResponseByID{
+		PackageResponse: PackageResponse{
+			PackageID:   pkg.PackageID,
+			Name:        pkg.Name,
+			Description: pkg.Description,
+			Price:       pkg.Price,
+			IsActive:    pkg.IsActive,
+			StartAt:     pkg.StartAt,
+			EndAt:       pkg.EndAt,
+			CreatedAt:   pkg.CreatedAt,
+			UpdatedAt:   pkg.UpdatedAt,
+		},
+		PackageItems: packageItems,
+	}
+	c.JSON(http.StatusOK, gin.H{"data": resp})
+}
+
+// @Summary		Update a package
+// @Description	Updates an existing package's information, including its items.
+// @Tags			Packages
+// @Security		ApiKeyAuth
+// @Accept			json
+// @Produce		json
+// @Param			id		path		string					true	"Package UUID"
+// @Param			package	body		CreatePackageRequest	true	"Payload with fields to update"
+// @Success		204		{object}	nil						"Package updated successfully"
+// @Failure		400		{object}	map[string]interface{}	"Bad Request: Invalid UUID or payload"
+// @Failure		404		{object}	map[string]interface{}	"Not Found: Package not found"
+// @Failure		500		{object}	map[string]interface{}	"Internal Server Error"
+// @Router			/packages/{id} [put]
+func (h *CombosHandler) UpdatePackageHandler(c *gin.Context) {
+	ctx := c.Request.Context()
+	packageID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		h.services.LogErrors.BadRequestResponse(c, err)
+		return
+	}
+
+	var payload CreatePackageRequest
+	if err := c.ShouldBindJSON(&payload); err != nil {
+		h.services.LogErrors.BadRequestResponse(c, err)
+		return
+	}
+
+	pkg, err := payload.ToPackage()
+	if err != nil {
+		h.services.LogErrors.BadRequestResponse(c, err)
+		return
+	}
+	pkg.PackageID = packageID
+
+	err = h.services.CombosServices.UpdatePackage(ctx, pkg)
+	if err != nil {
+		switch err {
+		case shared_errors.ErrNotFound:
+			h.services.LogErrors.NotFoundResponse(c)
+		default:
+			h.services.LogErrors.InternalServerError(c, err)
+		}
+		return
+	}
+	c.JSON(http.StatusNoContent, nil)
+}
+
+// @Summary		Delete a package
+// @Description	Deletes a specific package by its UUID.
+// @Tags			Packages
+// @Security		ApiKeyAuth
+// @Produce		json
+// @Param			id	path		string					true	"Package UUID"
+// @Success		204	{object}	nil						"Package deleted successfully"
+// @Failure		400	{object}	map[string]interface{}	"Bad Request: Invalid UUID format"
+// @Failure		404	{object}	map[string]interface{}	"Not Found: Package not found"
+// @Failure		500	{object}	map[string]interface{}	"Internal Server Error"
+// @Router			/packages/{id} [delete]
+func (h *CombosHandler) DeletePackageHandler(c *gin.Context) {
+	ctx := c.Request.Context()
+	packageID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		h.services.LogErrors.BadRequestResponse(c, err)
+		return
+	}
+	err = h.services.CombosServices.DeletePackage(ctx, packageID)
+	if err != nil {
+		switch err {
+		case shared_errors.ErrNotFound:
+			h.services.LogErrors.NotFoundResponse(c)
+		default:
+			h.services.LogErrors.InternalServerError(c, err)
+		}
+		return
+	}
+	c.JSON(http.StatusNoContent, nil)
+}

--- a/internal/modules/combos/handler/combos_handlers.go
+++ b/internal/modules/combos/handler/combos_handlers.go
@@ -47,13 +47,13 @@ func (h *CombosHandler) CreatePackageHandler(c *gin.Context) {
 // @Tags			Packages
 // @Security		ApiKeyAuth
 // @Produce		json
-// @Param			limit	query		int										false	"Number of results per page"	default(10)
-// @Param			page	query		int										false	"Page number for pagination"	default(1)
-// @Param			sort	query		string									false	"Sort order (asc/desc)"			enums(asc, desc)	default(desc)
-// @Param			search	query		string									false	"Search term for package name"
-// @Success		200		{object}	pagination.PaginatedResponseTotal[PackageResponse]	"A paginated list of packages"
-// @Failure		400		{object}	map[string]interface{}					"Bad Request: Invalid query parameters"
-// @Failure		500		{object}	map[string]interface{}					"Internal server error"
+// @Param			limit	query		int								false	"Number of results per page"	default(10)
+// @Param			page	query		int								false	"Page number for pagination"	default(1)
+// @Param			sort	query		string							false	"Sort order (asc/desc)"			enums(asc, desc)	default(desc)
+// @Param			search	query		string							false	"Search term for package name"
+// @Success		200		{object}	object{data=PackageResponse[]}	"A paginated list of packages"
+// @Failure		400		{object}	map[string]interface{}			"Bad Request: Invalid query parameters"
+// @Failure		500		{object}	map[string]interface{}			"Internal server error"
 // @Router			/packages [get]
 func (h *CombosHandler) GetPackageHandler(c *gin.Context) {
 	ctx := c.Request.Context()
@@ -116,11 +116,11 @@ func (h *CombosHandler) GetPackageHandler(c *gin.Context) {
 // @Tags			Packages
 // @Security		ApiKeyAuth
 // @Produce		json
-// @Param			id	path		string					true	"Package UUID"
+// @Param			id	path		string								true	"Package UUID"
 // @Success		200	{object}	object{data=PackageResponseByID}	"Package details"
-// @Failure		400	{object}	map[string]interface{}	"Bad Request: Invalid UUID format"
-// @Failure		404	{object}	map[string]interface{}	"Not Found: Package not found"
-// @Failure		500	{object}	map[string]interface{}	"Internal Server Error"
+// @Failure		400	{object}	map[string]interface{}				"Bad Request: Invalid UUID format"
+// @Failure		404	{object}	map[string]interface{}				"Not Found: Package not found"
+// @Failure		500	{object}	map[string]interface{}				"Internal Server Error"
 // @Router			/packages/{id} [get]
 func (h *CombosHandler) GetPackageByIDHandler(c *gin.Context) {
 	ctx := c.Request.Context()
@@ -145,6 +145,7 @@ func (h *CombosHandler) GetPackageByIDHandler(c *gin.Context) {
 	for i, item := range pkg.PackageItems {
 		packageItems[i] = PackageItemResponse{
 			ServiceID:        item.ServiceID,
+			Name:             item.Service.Name,
 			SessionsIncluded: item.SessionsIncluded,
 		}
 	}

--- a/internal/modules/combos/handler/payload.go
+++ b/internal/modules/combos/handler/payload.go
@@ -46,7 +46,7 @@ func (r *CreatePackageRequest) ToPackage() (*combosdomain.Package, error) {
 		pkg.EndAt = &endAt
 	}
 
-	pkg.PackageItems = make([]combosdomain.PackageItem, 0, len(r.PackageItems))
+	pkg.PackageItems = make([]combosdomain.PackageItem, len(r.PackageItems))
 	for i, item := range r.PackageItems {
 		serviceID, err := uuid.Parse(item.ServiceID)
 		if err != nil {
@@ -83,5 +83,6 @@ type PackageResponseByID struct {
 
 type PackageItemResponse struct {
 	ServiceID        uuid.UUID `json:"serviceId"`
+	Name             string    `json:"name"`
 	SessionsIncluded int       `json:"sessionsIncluded"`
 }

--- a/internal/modules/combos/handler/payload.go
+++ b/internal/modules/combos/handler/payload.go
@@ -1,0 +1,87 @@
+package comboshandler
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	combosdomain "github.com/vitalfit/api/internal/modules/combos/domain"
+)
+
+type CreatePackageItemRequest struct {
+	ServiceID        string `json:"serviceId" binding:"required"`
+	SessionsIncluded int    `json:"sessionsIncluded" binding:"required,min=1"`
+}
+
+type CreatePackageRequest struct {
+	Name        string  `json:"name" binding:"required"`
+	Description string  `json:"description"`
+	Price       float64 `json:"price" binding:"required,gt=0"`
+
+	StartAt string `json:"startAt,omitempty"`
+	EndAt   string `json:"endAt,omitempty"`
+
+	PackageItems []CreatePackageItemRequest `json:"packageItems" binding:"required,min=1"`
+}
+
+func (r *CreatePackageRequest) ToPackage() (*combosdomain.Package, error) {
+	var pkg combosdomain.Package
+
+	pkg.Name = r.Name
+	pkg.Description = r.Description
+	pkg.Price = r.Price
+
+	if r.StartAt != "" {
+		startAt, err := time.Parse(time.RFC3339, r.StartAt)
+		if err != nil {
+			return nil, err
+		}
+		pkg.StartAt = &startAt
+	}
+
+	if r.EndAt != "" {
+		endAt, err := time.Parse(time.RFC3339, r.EndAt)
+		if err != nil {
+			return nil, err
+		}
+		pkg.EndAt = &endAt
+	}
+
+	pkg.PackageItems = make([]combosdomain.PackageItem, 0, len(r.PackageItems))
+	for i, item := range r.PackageItems {
+		serviceID, err := uuid.Parse(item.ServiceID)
+		if err != nil {
+			return nil, err
+		}
+		pkg.PackageItems[i] = combosdomain.PackageItem{
+			ServiceID:        serviceID,
+			SessionsIncluded: item.SessionsIncluded,
+		}
+	}
+
+	return &pkg, nil
+}
+
+//response
+
+type PackageResponse struct {
+	PackageID   uuid.UUID  `json:"packageId"`
+	Name        string     `json:"name"`
+	Description string     `json:"description"`
+	Price       float64    `json:"price"`
+	IsActive    bool       `json:"isActive"`
+	StartAt     *time.Time `json:"startAt"`
+	EndAt       *time.Time `json:"endAt"`
+	CreatedAt   time.Time  `json:"createdAt"`
+	UpdatedAt   time.Time  `json:"updatedAt"`
+}
+
+type PackageResponseByID struct {
+	PackageResponse
+
+	PackageItems []PackageItemResponse `json:"packageItems"`
+}
+
+type PackageItemResponse struct {
+	ServiceID        uuid.UUID `json:"serviceId"`
+	SessionsIncluded int       `json:"sessionsIncluded"`
+}

--- a/internal/modules/combos/handler/routes.go
+++ b/internal/modules/combos/handler/routes.go
@@ -8,6 +8,11 @@ import (
 
 type CombosHandlerInterface interface {
 	CombosRoutes(rg *gin.RouterGroup, m *auth.AuthMiddleware)
+	CreatePackageHandler(c *gin.Context)
+	GetPackageHandler(c *gin.Context)
+	GetPackageByIDHandler(c *gin.Context)
+	UpdatePackageHandler(c *gin.Context)
+	DeletePackageHandler(c *gin.Context)
 }
 
 type CombosHandler struct {
@@ -19,5 +24,13 @@ func NewCombosHandler(services appservices.Services) *CombosHandler {
 }
 
 func (r *CombosHandler) CombosRoutes(rg *gin.RouterGroup, m *auth.AuthMiddleware) {
-
+	packagesGroup := rg.Group("/packages")
+	{
+		packagesGroup.Use(m.AuthJwtTokenMiddleware())
+		packagesGroup.POST("", m.RBACPermission("packages:create"), r.CreatePackageHandler)
+		packagesGroup.GET("", m.RBACPermission("packages:list"), r.GetPackageHandler)
+		packagesGroup.GET("/:id", m.RBACPermission("packages:get"), r.GetPackageByIDHandler)
+		packagesGroup.PUT("/:id", m.RBACPermission("packages:update"), r.UpdatePackageHandler)
+		packagesGroup.DELETE("/:id", m.RBACPermission("packages:delete"), r.DeletePackageHandler)
+	}
 }

--- a/internal/modules/combos/handler/routes.go
+++ b/internal/modules/combos/handler/routes.go
@@ -1,0 +1,23 @@
+package comboshandler
+
+import (
+	"github.com/gin-gonic/gin"
+	appservices "github.com/vitalfit/api/internal/app/services"
+	"github.com/vitalfit/api/internal/shared/middleware/auth"
+)
+
+type CombosHandlerInterface interface {
+	CombosRoutes(rg *gin.RouterGroup, m *auth.AuthMiddleware)
+}
+
+type CombosHandler struct {
+	services appservices.Services
+}
+
+func NewCombosHandler(services appservices.Services) *CombosHandler {
+	return &CombosHandler{services: services}
+}
+
+func (r *CombosHandler) CombosRoutes(rg *gin.RouterGroup, m *auth.AuthMiddleware) {
+
+}

--- a/internal/modules/combos/repository/packages_repository.go
+++ b/internal/modules/combos/repository/packages_repository.go
@@ -1,6 +1,17 @@
 package combosrepository
 
-import "gorm.io/gorm"
+import (
+	"context"
+	"errors"
+
+	"github.com/google/uuid"
+	combosdomain "github.com/vitalfit/api/internal/modules/combos/domain"
+	shared_errors "github.com/vitalfit/api/internal/shared/errors"
+	"github.com/vitalfit/api/pkg/db"
+	"github.com/vitalfit/api/pkg/pagination"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
 
 type CombosStore struct {
 	db *gorm.DB
@@ -8,4 +19,94 @@ type CombosStore struct {
 
 func NewCombosStore(db *gorm.DB) *CombosStore {
 	return &CombosStore{db: db}
+}
+
+func (s *CombosStore) CreatePackage(ctx context.Context, pkg *combosdomain.Package) error {
+	return db.WithTX(s.db, func(tx *gorm.DB) error {
+		return tx.WithContext(ctx).Create(pkg).Error
+	})
+}
+
+func (s *CombosStore) GetPackages(ctx context.Context, fq pagination.PaginatedFeedQuery) ([]*combosdomain.Package, error) {
+	var packages []*combosdomain.Package
+	query := s.db.WithContext(ctx)
+	if fq.Search != "" {
+		searchQuery := "%" + fq.Search + "%"
+		query = query.Where("name ILIKE ?", searchQuery)
+	}
+
+	err := query.Limit(fq.Limit).Offset(fq.Page*fq.Limit - fq.Limit).Order("created_at " + fq.Sort).Find(&packages).Error
+	return packages, err
+}
+
+func (s *CombosStore) GetPackagesTotal(ctx context.Context, fq pagination.PaginatedFeedQuery) (int64, error) {
+	var count int64
+	query := s.db.WithContext(ctx).Model(&combosdomain.Package{})
+	if fq.Search != "" {
+		searchQuery := "%" + fq.Search + "%"
+		query = query.Where("name ILIKE ?", searchQuery)
+	}
+	err := query.Count(&count).Error
+	if err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+func (s *CombosStore) GetPackageByID(ctx context.Context, packageID uuid.UUID) (*combosdomain.Package, error) {
+	var pkg combosdomain.Package
+	err := s.db.WithContext(ctx).Preload("PackageItems").First(&pkg, "package_id = ?", packageID).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, shared_errors.ErrNotFound
+		}
+		return nil, err
+	}
+	return &pkg, nil
+}
+
+func (s *CombosStore) UpdatePackage(ctx context.Context, pkg *combosdomain.Package) error {
+	return db.WithTX(s.db, func(tx *gorm.DB) error {
+		// Primero, verifica si el paquete existe
+		var existingPackage combosdomain.Package
+		if err := tx.WithContext(ctx).First(&existingPackage, "package_id = ?", pkg.PackageID).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return shared_errors.ErrNotFound
+			}
+			return err
+		}
+
+		// Actualiza los campos del paquete principal
+		if err := tx.WithContext(ctx).Model(&existingPackage).Updates(pkg).Error; err != nil {
+			return err
+		}
+
+		// Elimina los items existentes para reemplazarlos
+		if err := tx.WithContext(ctx).Where("package_id = ?", pkg.PackageID).Delete(&combosdomain.PackageItem{}).Error; err != nil {
+			return err
+		}
+
+		// Si hay nuevos items, créalos
+		if len(pkg.PackageItems) > 0 {
+			for i := range pkg.PackageItems {
+				pkg.PackageItems[i].PackageID = pkg.PackageID
+			}
+			if err := tx.WithContext(ctx).Clauses(clause.OnConflict{DoNothing: true}).Create(&pkg.PackageItems).Error; err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+}
+
+func (s *CombosStore) DeletePackage(ctx context.Context, packageID uuid.UUID) error {
+	result := s.db.WithContext(ctx).Delete(&combosdomain.Package{}, packageID)
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return shared_errors.ErrNotFound
+	}
+	return nil
 }

--- a/internal/modules/combos/repository/packages_repository.go
+++ b/internal/modules/combos/repository/packages_repository.go
@@ -1,0 +1,11 @@
+package combosrepository
+
+import "gorm.io/gorm"
+
+type CombosStore struct {
+	db *gorm.DB
+}
+
+func NewCombosStore(db *gorm.DB) *CombosStore {
+	return &CombosStore{db: db}
+}

--- a/internal/modules/combos/repository/packages_repository.go
+++ b/internal/modules/combos/repository/packages_repository.go
@@ -55,7 +55,7 @@ func (s *CombosStore) GetPackagesTotal(ctx context.Context, fq pagination.Pagina
 
 func (s *CombosStore) GetPackageByID(ctx context.Context, packageID uuid.UUID) (*combosdomain.Package, error) {
 	var pkg combosdomain.Package
-	err := s.db.WithContext(ctx).Preload("PackageItems").First(&pkg, "package_id = ?", packageID).Error
+	err := s.db.WithContext(ctx).Preload("PackageItems.Service").Preload("PackageItems").First(&pkg, "package_id = ?", packageID).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, shared_errors.ErrNotFound

--- a/internal/modules/combos/services/packages_service.go
+++ b/internal/modules/combos/services/packages_service.go
@@ -1,0 +1,11 @@
+package combosservices
+
+import "github.com/vitalfit/api/internal/store"
+
+type CombosServices struct {
+	store store.Storage
+}
+
+func NewCombosServices(store store.Storage) *CombosServices {
+	return &CombosServices{store: store}
+}

--- a/internal/modules/combos/services/packages_service.go
+++ b/internal/modules/combos/services/packages_service.go
@@ -1,6 +1,13 @@
 package combosservices
 
-import "github.com/vitalfit/api/internal/store"
+import (
+	"context"
+
+	"github.com/google/uuid"
+	combosdomain "github.com/vitalfit/api/internal/modules/combos/domain"
+	"github.com/vitalfit/api/internal/store"
+	"github.com/vitalfit/api/pkg/pagination"
+)
 
 type CombosServices struct {
 	store store.Storage
@@ -8,4 +15,28 @@ type CombosServices struct {
 
 func NewCombosServices(store store.Storage) *CombosServices {
 	return &CombosServices{store: store}
+}
+
+func (s *CombosServices) CreatePackage(ctx context.Context, pkg *combosdomain.Package) error {
+	return s.store.Combos.CreatePackage(ctx, pkg)
+}
+
+func (s *CombosServices) GetPackages(ctx context.Context, fq pagination.PaginatedFeedQuery) ([]*combosdomain.Package, error) {
+	return s.store.Combos.GetPackages(ctx, fq)
+}
+
+func (s *CombosServices) GetPackagesTotal(ctx context.Context, fq pagination.PaginatedFeedQuery) (int64, error) {
+	return s.store.Combos.GetPackagesTotal(ctx, fq)
+}
+
+func (s *CombosServices) GetPackageByID(ctx context.Context, packageID uuid.UUID) (*combosdomain.Package, error) {
+	return s.store.Combos.GetPackageByID(ctx, packageID)
+}
+
+func (s *CombosServices) UpdatePackage(ctx context.Context, pkg *combosdomain.Package) error {
+	return s.store.Combos.UpdatePackage(ctx, pkg)
+}
+
+func (s *CombosServices) DeletePackage(ctx context.Context, packageID uuid.UUID) error {
+	return s.store.Combos.DeletePackage(ctx, packageID)
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -7,6 +7,8 @@ import (
 	billingrepository "github.com/vitalfit/api/internal/modules/billing/repository"
 	branchdomain "github.com/vitalfit/api/internal/modules/branches/domain"
 	branchrepository "github.com/vitalfit/api/internal/modules/branches/repository"
+	combosdomain "github.com/vitalfit/api/internal/modules/combos/domain"
+	combosrepository "github.com/vitalfit/api/internal/modules/combos/repository"
 	instructordomain "github.com/vitalfit/api/internal/modules/instructor/domain"
 	instructorrepository "github.com/vitalfit/api/internal/modules/instructor/repository"
 	inventorydomain "github.com/vitalfit/api/internal/modules/inventory/domain"
@@ -36,6 +38,7 @@ type Storage struct {
 	Membership      membershipsdomain.MembershipsRepository
 	Billing         billingdomain.BillingRepository
 	Schedule        scheduledomain.ScheduleRepository
+	Combos          combosdomain.CombosRepository
 }
 
 func NewStorage(db *gorm.DB) Storage {
@@ -53,5 +56,6 @@ func NewStorage(db *gorm.DB) Storage {
 		Membership:      membershipsrepository.NewMembershipStore(db),
 		Billing:         billingrepository.NewBillingStore(db),
 		Schedule:        schedulerepository.NewScheduleStore(db),
+		Combos:          combosrepository.NewCombosStore(db),
 	}
 }


### PR DESCRIPTION
### Description
This Pull Request introduces the full CRUD (Create, Read, Update, Delete) functionality for managing "Packages" (Combos) in the system.

### The main changes include:

combos Module Initialization: The base structure for the new module has been created, including the domain, repository, and handlers.
Database Migrations: The necessary migrations were added to create the packages and package_items tables, establishing the corresponding relationships.
CRUD Endpoint Implementation:
POST /packages: Allows the creation of a new package along with its associated items.
GET /packages: Retrieves a list of all packages, implementing pagination, sorting, and searching by name.
GET /packages/{id}: Gets the full details of a specific package, including the list of services it contains.
PUT /packages/{id}: Updates the information of an existing package. The repository logic handles the update of items by deleting the old ones and creating the new ones.
DELETE /packages/{id}: Deletes a package from the system.
Response and Logic Enhancements:
The response of the list endpoint has been improved to include the total number of records (total) and URLs for pagination (next and previous), providing a better client experience.
The logic in the repository layer has been refined to ensure the atomicity of create and update operations through database transactions.
Related Issue
N/A. This is a new core feature for product management.

### Motivation and Context
The primary motivation for this change is to introduce a core capability into the system: the ability to create and manage "packages" or "combos". This functionality is essential to allow administrators to group multiple services into a single offering, either for promotional purposes or as a standard product.

Before this change, there was no mechanism to group services, which limited sales and marketing strategies. This PR solves that problem by providing a solid and complete foundation for package management.

### How Has This Been Tested?
Testing has been performed manually through an API client (like Postman) to verify the behavior of each of the new endpoints:

Creation (POST /packages): Verified that new packages can be created with and without items. Validated that the data is saved correctly in the database.
Listing (GET /packages): Tested pagination (page, limit), sorting (sort=asc/desc), and search functionality (search). Confirmed that the response includes the data, total, next, and previous fields.
Get by ID (GET /packages/{id}): Checked that requesting a package by its UUID returns all its data along with the details of the associated services. Tested the 404 error case for non-existent UUIDs.
Update (PUT /packages/{id}): Verified that the fields of a package can be modified and that the list of items is updated correctly (deleting the old ones and creating the new ones).
Deletion (DELETE /packages/{id}): Confirmed that a package can be deleted and that it returns a 204 No Content status. Validated that the record is removed from the database.
The testing environment is local, connected to a PostgreSQL development database running in Docker.

### Screenshots (if appropriate):
N/A