### PR TITLE
Fix: Get clients pagination and branch schedule permissions

### DIFF
--- a/internal/modules/auth/domain/repository.go
+++ b/internal/modules/auth/domain/repository.go
@@ -24,7 +24,7 @@ type UserRepository interface {
 	ValidateResetToken(ctx context.Context, key string) error
 	GetBranchAdmins(ctx context.Context, fq pagination.PaginatedFeedQuery) ([]*Users, error)
 	GetUsers(ctx context.Context, fq pagination.PaginatedFeedQuery) ([]*Users, error)
-	GetClients(ctx context.Context, fq pagination.PaginatedFeedQuery) ([]*Users, error)
+	GetClients(ctx context.Context, fq pagination.PaginatedFeedQuery) ([]*Users, int64, error)
 	UpdateUserClient(ctx context.Context, user *Users) error
 	UpdateUserStaff(ctx context.Context, user *Users) error
 	SoftDelete(ctx context.Context, userID uuid.UUID) error

--- a/internal/modules/auth/domain/service.go
+++ b/internal/modules/auth/domain/service.go
@@ -38,7 +38,7 @@ type UserServicesInterface interface {
 	GetUserFromContext(c *gin.Context) *Users
 	GetBranchAdmins(ctx context.Context, fq pagination.PaginatedFeedQuery) ([]*Users, error)
 	GetUsers(ctx context.Context, fq pagination.PaginatedFeedQuery) ([]*Users, error)
-	GetClients(ctx context.Context, fq pagination.PaginatedFeedQuery) ([]*Users, error)
+	GetClients(ctx context.Context, fq pagination.PaginatedFeedQuery) ([]*Users, int64, error)
 	UpdateClient(ctx context.Context, user *Users) error
 	UpdateStaff(ctx context.Context, user *Users, roleName string) error
 	Delete(ctx context.Context, userID uuid.UUID) error

--- a/internal/modules/auth/handlers/handlers_test.go
+++ b/internal/modules/auth/handlers/handlers_test.go
@@ -652,7 +652,7 @@ func TestUserListHandlers(t *testing.T) {
 
 	t.Run("GetClientsHandler", func(t *testing.T) {
 		setupMiddleware()
-		userStoreMock.On("GetClients", mock.Anything, mock.AnythingOfType("pagination.PaginatedFeedQuery")).Return(mockUsers, nil).Once()
+		userStoreMock.On("GetClients", mock.Anything, mock.AnythingOfType("pagination.PaginatedFeedQuery")).Return(mockUsers, len(mockUsers), nil).Once()
 
 		req, _ := http.NewRequest(http.MethodGet, "/v1/user/clients", nil)
 		req.Header.Set("Authorization", "Bearer "+adminToken)

--- a/internal/modules/auth/handlers/user_auth_handlers.go
+++ b/internal/modules/auth/handlers/user_auth_handlers.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/MicahParks/keyfunc/v2"
@@ -607,6 +608,9 @@ func (h *AuthHandlers) GetUsersHandler(c *gin.Context) {
 func (h *AuthHandlers) GetClientsHandler(c *gin.Context) {
 	ctx := c.Request.Context()
 	fq := pagination.PaginatedFeedQuery{
+		Limit:  10,
+		Page:   1,
+		Sort:   "desc",
 		Search: "",
 	}
 
@@ -616,7 +620,14 @@ func (h *AuthHandlers) GetClientsHandler(c *gin.Context) {
 		return
 	}
 
-	users, err := h.services.UserServices.GetClients(ctx, fq)
+	nextURL := fmt.Sprintf("/user/clients?limit=%d&page=%d&sort=%s", fq.Limit, fq.Page+1, fq.Sort)
+	previousPage := fq.Page - 1
+	if previousPage <= 0 {
+		previousPage = 1
+	}
+	previousURL := fmt.Sprintf("/user/clients?limit=%d&page=%d&sort=%s", fq.Limit, previousPage, fq.Sort)
+
+	users, total, err := h.services.UserServices.GetClients(ctx, fq)
 	if err != nil {
 		h.services.LogErrors.InternalServerError(c, err)
 		return
@@ -637,9 +648,15 @@ func (h *AuthHandlers) GetClientsHandler(c *gin.Context) {
 		responseList = append(responseList, resp)
 	}
 
-	c.JSON(http.StatusOK, gin.H{
-		"data": responseList,
-	})
+	resp := pagination.PaginatedResponseTotal[UserResponse]{
+		Data:     responseList,
+		Count:    int64(len(users)),
+		Next:     nextURL,
+		Previous: previousURL,
+		Total:    total,
+	}
+
+	c.JSON(http.StatusOK, resp)
 }
 
 // @Summary		Get user by ID

--- a/internal/modules/auth/mocks/repository_mocks.go
+++ b/internal/modules/auth/mocks/repository_mocks.go
@@ -109,12 +109,12 @@ func (m *UserStoreMock) GetUsers(ctx context.Context, fq pagination.PaginatedFee
 	return args.Get(0).([]*authdomain.Users), args.Error(1)
 }
 
-func (m *UserStoreMock) GetClients(ctx context.Context, fq pagination.PaginatedFeedQuery) ([]*authdomain.Users, error) {
+func (m *UserStoreMock) GetClients(ctx context.Context, fq pagination.PaginatedFeedQuery) ([]*authdomain.Users, int64, error) {
 	args := m.Called(ctx, fq)
 	if args.Get(0) == nil {
-		return nil, args.Error(1)
+		return nil, int64(args.Int(1)), args.Error(2)
 	}
-	return args.Get(0).([]*authdomain.Users), args.Error(1)
+	return args.Get(0).([]*authdomain.Users), int64(args.Int(1)), args.Error(2)
 }
 
 func (m *UserStoreMock) UpdateUserStaff(ctx context.Context, user *authdomain.Users) error {

--- a/internal/modules/auth/repository/user.repository.go
+++ b/internal/modules/auth/repository/user.repository.go
@@ -117,19 +117,27 @@ func (s *UserStore) GetUsers(ctx context.Context, fq pagination.PaginatedFeedQue
 	return users, nil
 }
 
-func (s *UserStore) GetClients(ctx context.Context, fq pagination.PaginatedFeedQuery) ([]*authdomain.Users, error) {
+func (s *UserStore) GetClients(ctx context.Context, fq pagination.PaginatedFeedQuery) ([]*authdomain.Users, int64, error) {
 	var users []*authdomain.Users
+	var total int64
 	searchQuery := "%" + fq.Search + "%"
-	err := s.db.WithContext(ctx).
+
+	query := s.db.WithContext(ctx).
+		Model(&authdomain.Users{}).
 		Joins("JOIN roles ON roles.role_id = users.role_id").
-		Preload("Role").
 		Where("roles.name = ?", "client").
-		Where("users.first_name ILIKE ? OR users.last_name ILIKE ? OR CONCAT(users.first_name, ' ', users.last_name) ILIKE ?", searchQuery, searchQuery, searchQuery).
-		Find(&users).Error
-	if err != nil {
-		return nil, err
+		Where("users.first_name ILIKE ? OR users.last_name ILIKE ? OR CONCAT(users.first_name, ' ', users.last_name) ILIKE ?", searchQuery, searchQuery, searchQuery)
+
+	if err := query.Count(&total).Error; err != nil {
+		return nil, 0, err
 	}
-	return users, nil
+
+	err := query.Preload("Role").Limit(fq.Limit).Offset(fq.Page*fq.Limit - fq.Limit).Order("users.created_at " + fq.Sort).Find(&users).Error
+
+	if err != nil {
+		return nil, 0, err
+	}
+	return users, total, nil
 }
 
 func (s *UserStore) CreateAndInvitate(ctx context.Context, user *authdomain.Users, token string, invitationExp time.Duration) error {

--- a/internal/modules/auth/services/service_test.go
+++ b/internal/modules/auth/services/service_test.go
@@ -362,6 +362,29 @@ func TestUserService(t *testing.T) {
 		})
 	})
 
+	t.Run("GetClients", func(t *testing.T) {
+		t.Run("success", func(t *testing.T) {
+			mockClients := []*authdomain.Users{{UserID: uuid.New(), FirstName: "Client"}}
+			total := 1
+			fq := pagination.PaginatedFeedQuery{Limit: 10, Page: 1}
+			userStoreMock.On("GetClients", mock.Anything, fq).Return(mockClients, total, nil).Once()
+
+			clients, count, err := userService.GetClients(context.Background(), fq)
+			assert.NoError(t, err)
+			assert.Equal(t, mockClients, clients)
+			assert.Equal(t, int64(total), count)
+			userStoreMock.AssertExpectations(t)
+		})
+
+		t.Run("failure", func(t *testing.T) {
+			fq := pagination.PaginatedFeedQuery{Limit: 10, Page: 1}
+			userStoreMock.On("GetClients", mock.Anything, fq).Return(nil, 0, assert.AnError).Once()
+			_, _, err := userService.GetClients(context.Background(), fq)
+			assert.Error(t, err)
+			userStoreMock.AssertExpectations(t)
+		})
+	})
+
 	t.Run("UpdateClient", func(t *testing.T) {
 		userToUpdate := &authdomain.Users{UserID: mockUser.UserID, FirstName: "Updated Client"}
 		userStoreMock.On("UpdateUserClient", mock.Anything, userToUpdate).Return(nil).Once()

--- a/internal/modules/auth/services/user.go
+++ b/internal/modules/auth/services/user.go
@@ -74,12 +74,12 @@ func (h *UserService) GetUsers(ctx context.Context, fq pagination.PaginatedFeedQ
 	}
 	return users, nil
 }
-func (h *UserService) GetClients(ctx context.Context, fq pagination.PaginatedFeedQuery) ([]*authdomain.Users, error) {
-	users, err := h.store.Users.GetClients(ctx, fq)
+func (h *UserService) GetClients(ctx context.Context, fq pagination.PaginatedFeedQuery) ([]*authdomain.Users, int64, error) {
+	users, total, err := h.store.Users.GetClients(ctx, fq)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
-	return users, nil
+	return users, total, nil
 }
 
 func (h *UserService) Delete(ctx context.Context, userID uuid.UUID) error {

--- a/internal/modules/schedule/handlers/routes.go
+++ b/internal/modules/schedule/handlers/routes.go
@@ -31,14 +31,14 @@ func (h *ScheduleHandlers) ScheduleRoutes(rg *gin.RouterGroup, m *auth.AuthMiddl
 		branchSchedule.Use(m.AuthJwtTokenMiddleware())
 
 		branchSchedule.POST("", m.RBACPermission("schedule:create"), h.CreateClassHandler)
-		branchSchedule.GET("", m.RBACPermission("schedule:list"), h.GetClassesByBranchHandler)
+		branchSchedule.GET("", h.GetClassesByBranchHandler)
 	}
 
 	classRoutes := rg.Group("/schedule")
 	{
 		classRoutes.Use(m.AuthJwtTokenMiddleware())
 
-		classRoutes.GET("/:classId", m.RBACPermission("schedule:get"), h.GetClassByIDHandler)
+		classRoutes.GET("/:classId", h.GetClassByIDHandler)
 		classRoutes.PUT("/:classId", m.RBACPermission("schedule:update"), h.UpdateClassHandler)
 		classRoutes.DELETE("/:classId", m.RBACPermission("schedule:delete"), h.DeleteClassHandler)
 	}

--- a/internal/modules/schedule/handlers/schedule_handlers.go
+++ b/internal/modules/schedule/handlers/schedule_handlers.go
@@ -73,6 +73,22 @@ func (h *ScheduleHandlers) CreateClassHandler(c *gin.Context) {
 func (h *ScheduleHandlers) GetClassesByBranchHandler(c *gin.Context) {
 	ctx := c.Request.Context()
 
+	user := h.services.UserServices.GetUserFromContext(c)
+
+	if user.Role.Name != "client" {
+		permission := "schedule:list"
+		if user.Role.Name != "super_admin" {
+			ok, err := h.services.UserServices.RoleHasPermission(ctx, user.RoleID, permission)
+			if err != nil {
+				h.services.LogErrors.InternalServerError(c, err)
+				return
+			}
+			if !ok {
+				h.services.LogErrors.ForbiddenResponse(c)
+				return
+			}
+		}
+	}
 	branchID, err := uuid.Parse(c.Param("id"))
 	if err != nil {
 		h.services.LogErrors.BadRequestResponse(c, err)
@@ -126,6 +142,22 @@ func (h *ScheduleHandlers) GetClassesByBranchHandler(c *gin.Context) {
 func (h *ScheduleHandlers) GetClassByIDHandler(c *gin.Context) {
 	ctx := c.Request.Context()
 
+	user := h.services.UserServices.GetUserFromContext(c)
+
+	if user.Role.Name != "client" {
+		permission := "schedule:get"
+		if user.Role.Name != "super_admin" {
+			ok, err := h.services.UserServices.RoleHasPermission(ctx, user.RoleID, permission)
+			if err != nil {
+				h.services.LogErrors.InternalServerError(c, err)
+				return
+			}
+			if !ok {
+				h.services.LogErrors.ForbiddenResponse(c)
+				return
+			}
+		}
+	}
 	classID, err := uuid.Parse(c.Param("classId"))
 	if err != nil {
 		h.services.LogErrors.BadRequestResponse(c, err)


### PR DESCRIPTION
### Description

This Pull Request addresses two reported bugs:

    Client Pagination Issue: Fixes a bug in the client retrieval endpoint related to pagination, ensuring clients are correctly paginated and displayed.

    Branch Schedule Permission Issue: Fixes a bug related to permissions for accessing the branch schedule retrieval endpoint (get branchschdule), ensuring correct authorization is applied.


### Motivation and Context

This change is required to address existing bugs that are impacting application stability and user experience, specifically regarding data retrieval and access control. This aligns with the project's maintenance mode policy of accepting bug fixes only.
### How Has This Been Tested?

    For fix get clients pagination: Testing was performed by verifying the client retrieval endpoint with various pagination parameters (e.g., page size, page number) to ensure the returned data is accurate and the pagination logic works as expected.

    For fix permissions for get branchschdule: Testing involved checking the get branchschdule endpoint with different user roles and permissions to confirm that authorized users can access the data and unauthorized users are correctly blocked.

Screenshots (if appropriate):

N/A (Backend/logic fixes)