### PR TITLE
feat(memberships): implement cancellation reasons CRUD

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -6792,6 +6792,272 @@ const docTemplate = `{
                 }
             }
         },
+        "/memberships/cancellation-reasons": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Retrieves all cancellation reasons, ordered alphabetically by description.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Memberships"
+                ],
+                "summary": "List all cancellation reasons",
+                "responses": {
+                    "200": {
+                        "description": "List of cancellation reasons",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/membershipshandlers.CancellationReasonResponse"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "error: Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Adds a new standardized cancellation reason for memberships.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Memberships"
+                ],
+                "summary": "Create a new cancellation reason",
+                "parameters": [
+                    {
+                        "description": "Cancellation reason creation payload",
+                        "name": "reason",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/membershipshandlers.CreateCancellationReasonPayload"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Cancellation reason created successfully",
+                        "schema": {
+                            "$ref": "#/definitions/membershipshandlers.CancellationReasonResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "error: Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "error: Conflict - Description already exists",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "error: Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/memberships/cancellation-reasons/{id}": {
+            "put": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Updates an existing cancellation reason's description and/or active status.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Memberships"
+                ],
+                "summary": "Update a cancellation reason",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Cancellation Reason UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Cancellation reason update payload",
+                        "name": "reason",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/membershipshandlers.UpdateCancellationReasonPayload"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Cancellation reason updated successfully",
+                        "schema": {
+                            "$ref": "#/definitions/membershipshandlers.CancellationReasonResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "error: Bad Request - Invalid ID or payload",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "error: Not Found - Cancellation reason not found",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "error: Conflict - Description already exists",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "error: Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Soft deletes a cancellation reason by setting the deleted_at timestamp.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Memberships"
+                ],
+                "summary": "Delete a cancellation reason",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Cancellation Reason UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "error: Bad Request - Invalid ID",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "error: Not Found - Cancellation reason not found",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "error: Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/packages": {
             "get": {
                 "security": [
@@ -11564,6 +11830,12 @@ const docTemplate = `{
         "membershipsdomain.CancellationReason": {
             "type": "object",
             "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "deleted_at": {
+                    "type": "string"
+                },
                 "description": {
                     "type": "string"
                 },
@@ -11572,6 +11844,9 @@ const docTemplate = `{
                 },
                 "reason_id": {
                     "description": "Mapeo a cancellation_reasons",
+                    "type": "string"
+                },
+                "updated_at": {
                     "type": "string"
                 }
             }
@@ -11690,6 +11965,34 @@ const docTemplate = `{
                 }
             }
         },
+        "membershipshandlers.CancellationReasonResponse": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "is_active": {
+                    "type": "boolean"
+                },
+                "reason_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "membershipshandlers.CreateCancellationReasonPayload": {
+            "type": "object",
+            "required": [
+                "description"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "is_active": {
+                    "type": "boolean"
+                }
+            }
+        },
         "membershipshandlers.CreateMembershipPayload": {
             "type": "object",
             "required": [
@@ -11767,6 +12070,17 @@ const docTemplate = `{
                 },
                 "price": {
                     "type": "number"
+                }
+            }
+        },
+        "membershipshandlers.UpdateCancellationReasonPayload": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "is_active": {
+                    "type": "boolean"
                 }
             }
         },

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -6807,6 +6807,39 @@ const docTemplate = `{
                     "Memberships"
                 ],
                 "summary": "List all cancellation reasons",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "default": 10,
+                        "description": "Number of results per page",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 1,
+                        "description": "Page number for pagination",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "asc",
+                            "desc"
+                        ],
+                        "type": "string",
+                        "default": "asc",
+                        "description": "Sort direction (asc/desc)",
+                        "name": "sort",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search term",
+                        "name": "search",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "List of cancellation reasons",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -6799,6 +6799,39 @@
                     "Memberships"
                 ],
                 "summary": "List all cancellation reasons",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "default": 10,
+                        "description": "Number of results per page",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 1,
+                        "description": "Page number for pagination",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "asc",
+                            "desc"
+                        ],
+                        "type": "string",
+                        "default": "asc",
+                        "description": "Sort direction (asc/desc)",
+                        "name": "sort",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search term",
+                        "name": "search",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "List of cancellation reasons",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -6784,6 +6784,272 @@
                 }
             }
         },
+        "/memberships/cancellation-reasons": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Retrieves all cancellation reasons, ordered alphabetically by description.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Memberships"
+                ],
+                "summary": "List all cancellation reasons",
+                "responses": {
+                    "200": {
+                        "description": "List of cancellation reasons",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/membershipshandlers.CancellationReasonResponse"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "error: Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Adds a new standardized cancellation reason for memberships.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Memberships"
+                ],
+                "summary": "Create a new cancellation reason",
+                "parameters": [
+                    {
+                        "description": "Cancellation reason creation payload",
+                        "name": "reason",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/membershipshandlers.CreateCancellationReasonPayload"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Cancellation reason created successfully",
+                        "schema": {
+                            "$ref": "#/definitions/membershipshandlers.CancellationReasonResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "error: Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "error: Conflict - Description already exists",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "error: Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/memberships/cancellation-reasons/{id}": {
+            "put": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Updates an existing cancellation reason's description and/or active status.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Memberships"
+                ],
+                "summary": "Update a cancellation reason",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Cancellation Reason UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Cancellation reason update payload",
+                        "name": "reason",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/membershipshandlers.UpdateCancellationReasonPayload"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Cancellation reason updated successfully",
+                        "schema": {
+                            "$ref": "#/definitions/membershipshandlers.CancellationReasonResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "error: Bad Request - Invalid ID or payload",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "error: Not Found - Cancellation reason not found",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "error: Conflict - Description already exists",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "error: Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Soft deletes a cancellation reason by setting the deleted_at timestamp.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Memberships"
+                ],
+                "summary": "Delete a cancellation reason",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Cancellation Reason UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "error: Bad Request - Invalid ID",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "error: Not Found - Cancellation reason not found",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "error: Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/packages": {
             "get": {
                 "security": [
@@ -11556,6 +11822,12 @@
         "membershipsdomain.CancellationReason": {
             "type": "object",
             "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "deleted_at": {
+                    "type": "string"
+                },
                 "description": {
                     "type": "string"
                 },
@@ -11564,6 +11836,9 @@
                 },
                 "reason_id": {
                     "description": "Mapeo a cancellation_reasons",
+                    "type": "string"
+                },
+                "updated_at": {
                     "type": "string"
                 }
             }
@@ -11682,6 +11957,34 @@
                 }
             }
         },
+        "membershipshandlers.CancellationReasonResponse": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "is_active": {
+                    "type": "boolean"
+                },
+                "reason_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "membershipshandlers.CreateCancellationReasonPayload": {
+            "type": "object",
+            "required": [
+                "description"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "is_active": {
+                    "type": "boolean"
+                }
+            }
+        },
         "membershipshandlers.CreateMembershipPayload": {
             "type": "object",
             "required": [
@@ -11759,6 +12062,17 @@
                 },
                 "price": {
                     "type": "number"
+                }
+            }
+        },
+        "membershipshandlers.UpdateCancellationReasonPayload": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "is_active": {
+                    "type": "boolean"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1532,12 +1532,18 @@ definitions:
     type: object
   membershipsdomain.CancellationReason:
     properties:
+      created_at:
+        type: string
+      deleted_at:
+        type: string
       description:
         type: string
       is_active:
         type: boolean
       reason_id:
         description: Mapeo a cancellation_reasons
+        type: string
+      updated_at:
         type: string
     type: object
   membershipsdomain.ClientMembership:
@@ -1616,6 +1622,24 @@ definitions:
       user_id:
         type: string
     type: object
+  membershipshandlers.CancellationReasonResponse:
+    properties:
+      description:
+        type: string
+      is_active:
+        type: boolean
+      reason_id:
+        type: string
+    type: object
+  membershipshandlers.CreateCancellationReasonPayload:
+    properties:
+      description:
+        type: string
+      is_active:
+        type: boolean
+    required:
+    - description
+    type: object
   membershipshandlers.CreateMembershipPayload:
     properties:
       description:
@@ -1668,6 +1692,13 @@ definitions:
         type: string
       price:
         type: number
+    type: object
+  membershipshandlers.UpdateCancellationReasonPayload:
+    properties:
+      description:
+        type: string
+      is_active:
+        type: boolean
     type: object
   membershipshandlers.UpdateClientMembershipPayload:
     properties:
@@ -6535,6 +6566,174 @@ paths:
       security:
       - ApiKeyAuth: []
       summary: Get a summary of membership types
+      tags:
+      - Memberships
+  /memberships/cancellation-reasons:
+    get:
+      description: Retrieves all cancellation reasons, ordered alphabetically by description.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: List of cancellation reasons
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/definitions/membershipshandlers.CancellationReasonResponse'
+                type: array
+            type: object
+        "500":
+          description: 'error: Internal Server Error'
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+      security:
+      - ApiKeyAuth: []
+      summary: List all cancellation reasons
+      tags:
+      - Memberships
+    post:
+      consumes:
+      - application/json
+      description: Adds a new standardized cancellation reason for memberships.
+      parameters:
+      - description: Cancellation reason creation payload
+        in: body
+        name: reason
+        required: true
+        schema:
+          $ref: '#/definitions/membershipshandlers.CreateCancellationReasonPayload'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Cancellation reason created successfully
+          schema:
+            $ref: '#/definitions/membershipshandlers.CancellationReasonResponse'
+        "400":
+          description: 'error: Bad Request'
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+        "409":
+          description: 'error: Conflict - Description already exists'
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+        "500":
+          description: 'error: Internal Server Error'
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+      security:
+      - ApiKeyAuth: []
+      summary: Create a new cancellation reason
+      tags:
+      - Memberships
+  /memberships/cancellation-reasons/{id}:
+    delete:
+      description: Soft deletes a cancellation reason by setting the deleted_at timestamp.
+      parameters:
+      - description: Cancellation Reason UUID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: 'error: Bad Request - Invalid ID'
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+        "404":
+          description: 'error: Not Found - Cancellation reason not found'
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+        "500":
+          description: 'error: Internal Server Error'
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+      security:
+      - ApiKeyAuth: []
+      summary: Delete a cancellation reason
+      tags:
+      - Memberships
+    put:
+      consumes:
+      - application/json
+      description: Updates an existing cancellation reason's description and/or active
+        status.
+      parameters:
+      - description: Cancellation Reason UUID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Cancellation reason update payload
+        in: body
+        name: reason
+        required: true
+        schema:
+          $ref: '#/definitions/membershipshandlers.UpdateCancellationReasonPayload'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Cancellation reason updated successfully
+          schema:
+            $ref: '#/definitions/membershipshandlers.CancellationReasonResponse'
+        "400":
+          description: 'error: Bad Request - Invalid ID or payload'
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+        "404":
+          description: 'error: Not Found - Cancellation reason not found'
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+        "409":
+          description: 'error: Conflict - Description already exists'
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+        "500":
+          description: 'error: Internal Server Error'
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+      security:
+      - ApiKeyAuth: []
+      summary: Update a cancellation reason
       tags:
       - Memberships
   /packages:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -6571,6 +6571,29 @@ paths:
   /memberships/cancellation-reasons:
     get:
       description: Retrieves all cancellation reasons, ordered alphabetically by description.
+      parameters:
+      - default: 10
+        description: Number of results per page
+        in: query
+        name: limit
+        type: integer
+      - default: 1
+        description: Page number for pagination
+        in: query
+        name: page
+        type: integer
+      - default: asc
+        description: Sort direction (asc/desc)
+        enum:
+        - asc
+        - desc
+        in: query
+        name: sort
+        type: string
+      - description: Search term
+        in: query
+        name: search
+        type: string
       produces:
       - application/json
       responses:

--- a/internal/migrate/migrations/000035_add_timestamps_to_cancellation_reasons.down.sql
+++ b/internal/migrate/migrations/000035_add_timestamps_to_cancellation_reasons.down.sql
@@ -1,0 +1,6 @@
+DROP INDEX IF EXISTS idx_cancellation_reasons_deleted_at;
+
+ALTER TABLE cancellation_reasons
+DROP COLUMN IF EXISTS deleted_at,
+DROP COLUMN IF EXISTS updated_at,
+DROP COLUMN IF EXISTS created_at;

--- a/internal/migrate/migrations/000035_add_timestamps_to_cancellation_reasons.up.sql
+++ b/internal/migrate/migrations/000035_add_timestamps_to_cancellation_reasons.up.sql
@@ -1,0 +1,12 @@
+ALTER TABLE cancellation_reasons
+ADD COLUMN created_at TIMESTAMP DEFAULT NOW(),
+ADD COLUMN updated_at TIMESTAMP,
+ADD COLUMN deleted_at TIMESTAMP;
+
+-- Update existing records to have created_at set to current time
+UPDATE cancellation_reasons
+SET created_at = NOW()
+WHERE created_at IS NULL;
+
+-- Create index on deleted_at for soft delete queries
+CREATE INDEX idx_cancellation_reasons_deleted_at ON cancellation_reasons(deleted_at);

--- a/internal/modules/marketing/domain/marketing.go
+++ b/internal/modules/marketing/domain/marketing.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"gorm.io/gorm"
 )
 
 type DiscountType string
@@ -35,17 +36,17 @@ func (BannerService) TableName() string {
 }
 
 type Promotion struct {
-	PromotionID   uuid.UUID    `gorm:"type:uuid;primaryKey;default:uuid_generate_v4()" json:"promotion_id"`
-	Name          string       `gorm:"type:varchar(255);not null" json:"name"`
-	Code          string       `gorm:"type:varchar(50);unique" json:"code"`
-	DiscountType  DiscountType `gorm:"type:varchar(50);not null" json:"discount_type"`
-	DiscountValue float64      `gorm:"type:decimal(10,2);not null" json:"discount_value"`
-	StartDate     time.Time    `gorm:"not null" json:"start_date"`
-	EndDate       time.Time    `gorm:"not null" json:"end_date"`
-	IsActive      bool         `gorm:"not null;default:true" json:"is_active"`
-	CreatedAt     time.Time    `gorm:"default:now()" json:"created_at"`
-	UpdatedAt     *time.Time   `json:"updated_at,omitempty"`
-	DeletedAt     *time.Time   `gorm:"index" json:"deleted_at,omitempty"`
+	PromotionID   uuid.UUID      `gorm:"type:uuid;primaryKey;default:uuid_generate_v4()" json:"promotion_id"`
+	Name          string         `gorm:"type:varchar(255);not null" json:"name"`
+	Code          string         `gorm:"type:varchar(50);unique" json:"code"`
+	DiscountType  DiscountType   `gorm:"type:varchar(50);not null" json:"discount_type"`
+	DiscountValue float64        `gorm:"type:decimal(10,2);not null" json:"discount_value"`
+	StartDate     time.Time      `gorm:"not null" json:"start_date"`
+	EndDate       time.Time      `gorm:"not null" json:"end_date"`
+	IsActive      bool           `gorm:"not null;default:true" json:"is_active"`
+	CreatedAt     time.Time      `gorm:"default:now()" json:"created_at"`
+	UpdatedAt     *time.Time     `json:"updated_at,omitempty"`
+	DeletedAt     gorm.DeletedAt `gorm:"index" json:"deleted_at,omitempty" swaggertype:"primitive,string"`
 }
 
 func (Promotion) TableName() string {

--- a/internal/modules/memberships/domain/membership.go
+++ b/internal/modules/memberships/domain/membership.go
@@ -39,12 +39,12 @@ const (
 
 type CancellationReason struct {
 	// Mapeo a cancellation_reasons
-	ReasonID    uuid.UUID  `gorm:"type:uuid;primaryKey;default:gen_random_uuid()" json:"reason_id"`
-	Description string     `gorm:"type:varchar(255);unique;not null" json:"description"`
-	IsActive    bool       `gorm:"type:boolean;not null;default:true" json:"is_active"`
-	CreatedAt   time.Time  `gorm:"default:now()" json:"created_at"`
-	UpdatedAt   *time.Time `json:"updated_at,omitempty"`
-	DeletedAt   *time.Time `gorm:"index" json:"deleted_at,omitempty"`
+	ReasonID    uuid.UUID      `gorm:"type:uuid;primaryKey;default:gen_random_uuid()" json:"reason_id"`
+	Description string         `gorm:"type:varchar(255);unique;not null" json:"description"`
+	IsActive    bool           `gorm:"type:boolean;not null;default:true" json:"is_active"`
+	CreatedAt   time.Time      `gorm:"default:now()" json:"created_at"`
+	UpdatedAt   *time.Time     `json:"updated_at,omitempty"`
+	DeletedAt   gorm.DeletedAt `gorm:"index" json:"deleted_at,omitempty" swaggertype:"primitive,string"`
 }
 
 func (CancellationReason) TableName() string {

--- a/internal/modules/memberships/domain/membership.go
+++ b/internal/modules/memberships/domain/membership.go
@@ -39,9 +39,12 @@ const (
 
 type CancellationReason struct {
 	// Mapeo a cancellation_reasons
-	ReasonID    uuid.UUID `gorm:"type:uuid;primaryKey;default:gen_random_uuid()" json:"reason_id"`
-	Description string    `gorm:"type:varchar(255);unique;not null" json:"description"`
-	IsActive    bool      `gorm:"type:boolean;not null;default:true" json:"is_active"`
+	ReasonID    uuid.UUID  `gorm:"type:uuid;primaryKey;default:gen_random_uuid()" json:"reason_id"`
+	Description string     `gorm:"type:varchar(255);unique;not null" json:"description"`
+	IsActive    bool       `gorm:"type:boolean;not null;default:true" json:"is_active"`
+	CreatedAt   time.Time  `gorm:"default:now()" json:"created_at"`
+	UpdatedAt   *time.Time `json:"updated_at,omitempty"`
+	DeletedAt   *time.Time `gorm:"index" json:"deleted_at,omitempty"`
 }
 
 func (CancellationReason) TableName() string {

--- a/internal/modules/memberships/domain/repository.go
+++ b/internal/modules/memberships/domain/repository.go
@@ -31,6 +31,6 @@ type MembershipsRepository interface {
 	UpdateCancellationReason(ctx context.Context, reason *CancellationReason) error
 	DeleteCancellationReason(ctx context.Context, id uuid.UUID) error
 	GetCancellationReasonByID(ctx context.Context, id uuid.UUID) (*CancellationReason, error)
-	GetCancellationReasons(ctx context.Context) ([]*CancellationReason, error)
+	GetCancellationReasons(ctx context.Context, fq pagination.PaginatedFeedQuery) ([]*CancellationReason, int64, error)
 	GetCancellationReasonByDescription(ctx context.Context, description string) (*CancellationReason, error)
 }

--- a/internal/modules/memberships/domain/repository.go
+++ b/internal/modules/memberships/domain/repository.go
@@ -26,4 +26,11 @@ type MembershipsRepository interface {
 	GetClientMembership(ctx context.Context, clientID uuid.UUID) (*ClientMembership, error)
 	GetClientsMemberships(ctx context.Context, fq pagination.PaginatedFeedQuery) ([]*ClientMembership, int64, error)
 	GetClientMembershipByID(ctx context.Context, clientMembershipID uuid.UUID) (*ClientMembership, error)
+
+	CreateCancellationReason(ctx context.Context, reason *CancellationReason) error
+	UpdateCancellationReason(ctx context.Context, reason *CancellationReason) error
+	DeleteCancellationReason(ctx context.Context, id uuid.UUID) error
+	GetCancellationReasonByID(ctx context.Context, id uuid.UUID) (*CancellationReason, error)
+	GetCancellationReasons(ctx context.Context) ([]*CancellationReason, error)
+	GetCancellationReasonByDescription(ctx context.Context, description string) (*CancellationReason, error)
 }

--- a/internal/modules/memberships/domain/service.go
+++ b/internal/modules/memberships/domain/service.go
@@ -26,5 +26,5 @@ type MembershipsServiceInterface interface {
 	UpdateCancellationReason(ctx context.Context, reason *CancellationReason) error
 	DeleteCancellationReason(ctx context.Context, id uuid.UUID) error
 	GetCancellationReasonByID(ctx context.Context, id uuid.UUID) (*CancellationReason, error)
-	GetCancellationReasons(ctx context.Context) ([]*CancellationReason, error)
+	GetCancellationReasons(ctx context.Context, fq pagination.PaginatedFeedQuery) ([]*CancellationReason, int64, error)
 }

--- a/internal/modules/memberships/domain/service.go
+++ b/internal/modules/memberships/domain/service.go
@@ -21,4 +21,10 @@ type MembershipsServiceInterface interface {
 	GetClientMembership(ctx context.Context, clientID uuid.UUID) (*ClientMembership, error)
 	GetClientsMemberships(ctx context.Context, fq pagination.PaginatedFeedQuery) ([]*ClientMembership, int64, error)
 	GetClientMembershipByID(ctx context.Context, clientMembershipID uuid.UUID) (*ClientMembership, error)
+
+	CreateCancellationReason(ctx context.Context, reason *CancellationReason) error
+	UpdateCancellationReason(ctx context.Context, reason *CancellationReason) error
+	DeleteCancellationReason(ctx context.Context, id uuid.UUID) error
+	GetCancellationReasonByID(ctx context.Context, id uuid.UUID) (*CancellationReason, error)
+	GetCancellationReasons(ctx context.Context) ([]*CancellationReason, error)
 }

--- a/internal/modules/memberships/handlers/membership_handler.go
+++ b/internal/modules/memberships/handlers/membership_handler.go
@@ -527,13 +527,37 @@ func (h *MembershipHandler) CreateCancellationReasonHandler(c *gin.Context) {
 // @Tags			Memberships
 // @Produce		json
 // @Security		ApiKeyAuth
-// @Success		200	{object}	object{data=[]CancellationReasonResponse}	"List of cancellation reasons"
-// @Failure		500	{object}	object{error=string}						"error: Internal Server Error"
+// @Param			limit	query		int											false	"Number of results per page"	default(10)
+// @Param			page	query		int											false	"Page number for pagination"	default(1)
+// @Param			sort	query		string										false	"Sort direction (asc/desc)"		enums(asc, desc)	default(asc)
+// @Param			search	query		string										false	"Search term"
+// @Success		200		{object}	object{data=[]CancellationReasonResponse}	"List of cancellation reasons"
+// @Failure		500		{object}	object{error=string}						"error: Internal Server Error"
 // @Router			/memberships/cancellation-reasons [get]
 func (h *MembershipHandler) GetCancellationReasonsHandler(c *gin.Context) {
 	ctx := c.Request.Context()
 
-	reasons, err := h.services.MembershipServices.GetCancellationReasons(ctx)
+	fq := pagination.PaginatedFeedQuery{
+		Limit:  10,
+		Page:   1,
+		Sort:   "asc",
+		Search: "",
+	}
+
+	fq, err := fq.Parse(c.Request)
+	if err != nil {
+		h.services.LogErrors.BadRequestResponse(c, err)
+		return
+	}
+
+	nextURL := fmt.Sprintf("/memberships/cancellation-reasons?limit=%d&page=%d&sort=%s&search=%s", fq.Limit, fq.Page+1, fq.Sort, fq.Search)
+	previousPage := fq.Page - 1
+	if previousPage <= 0 {
+		previousPage = 1
+	}
+	previousURL := fmt.Sprintf("/memberships/cancellation-reasons?limit=%d&page=%d&sort=%s&search=%s", fq.Limit, previousPage, fq.Sort, fq.Search)
+
+	reasons, total, err := h.services.MembershipServices.GetCancellationReasons(ctx, fq)
 	if err != nil {
 		h.services.LogErrors.InternalServerError(c, err)
 		return
@@ -548,7 +572,15 @@ func (h *MembershipHandler) GetCancellationReasonsHandler(c *gin.Context) {
 		})
 	}
 
-	c.JSON(http.StatusOK, gin.H{"data": data})
+	resp := pagination.PaginatedResponseTotal[*CancellationReasonResponse]{
+		Data:     data,
+		Count:    int64(len(reasons)),
+		Next:     nextURL,
+		Previous: previousURL,
+		Total:    total,
+	}
+
+	c.JSON(http.StatusOK, resp)
 }
 
 // @Summary		Update a cancellation reason

--- a/internal/modules/memberships/handlers/membership_handler.go
+++ b/internal/modules/memberships/handlers/membership_handler.go
@@ -474,3 +474,182 @@ func (h *MembershipHandler) UpdateClientMembership(c *gin.Context) {
 
 	c.JSON(http.StatusOK, gin.H{"message": "Client membership updated successfully"})
 }
+
+// Cancellation Reasons Handlers
+
+// @Summary		Create a new cancellation reason
+// @Description	Adds a new standardized cancellation reason for memberships.
+// @Tags			Memberships
+// @Accept			json
+// @Produce		json
+// @Security		ApiKeyAuth
+// @Param			reason	body		CreateCancellationReasonPayload	true	"Cancellation reason creation payload"
+// @Success		201		{object}	CancellationReasonResponse		"Cancellation reason created successfully"
+// @Failure		400		{object}	object{error=string}			"error: Bad Request"
+// @Failure		409		{object}	object{error=string}			"error: Conflict - Description already exists"
+// @Failure		500		{object}	object{error=string}			"error: Internal Server Error"
+// @Router			/memberships/cancellation-reasons [post]
+func (h *MembershipHandler) CreateCancellationReasonHandler(c *gin.Context) {
+	ctx := c.Request.Context()
+	var payload CreateCancellationReasonPayload
+
+	if err := c.ShouldBindJSON(&payload); err != nil {
+		h.services.LogErrors.BadRequestResponse(c, err)
+		return
+	}
+
+	reason := &membershipsdomain.CancellationReason{
+		Description: payload.Description,
+		IsActive:    payload.IsActive,
+	}
+
+	if err := h.services.MembershipServices.CreateCancellationReason(ctx, reason); err != nil {
+		switch err {
+		case shared_errors.ErrConflict:
+			h.services.LogErrors.ConflictResponse(c, err)
+		default:
+			h.services.LogErrors.InternalServerError(c, err)
+		}
+		return
+	}
+
+	resp := &CancellationReasonResponse{
+		ReasonID:    reason.ReasonID,
+		Description: reason.Description,
+		IsActive:    reason.IsActive,
+	}
+
+	c.JSON(http.StatusCreated, resp)
+}
+
+// @Summary		List all cancellation reasons
+// @Description	Retrieves all cancellation reasons, ordered alphabetically by description.
+// @Tags			Memberships
+// @Produce		json
+// @Security		ApiKeyAuth
+// @Success		200	{object}	object{data=[]CancellationReasonResponse}	"List of cancellation reasons"
+// @Failure		500	{object}	object{error=string}						"error: Internal Server Error"
+// @Router			/memberships/cancellation-reasons [get]
+func (h *MembershipHandler) GetCancellationReasonsHandler(c *gin.Context) {
+	ctx := c.Request.Context()
+
+	reasons, err := h.services.MembershipServices.GetCancellationReasons(ctx)
+	if err != nil {
+		h.services.LogErrors.InternalServerError(c, err)
+		return
+	}
+
+	data := make([]*CancellationReasonResponse, 0, len(reasons))
+	for _, r := range reasons {
+		data = append(data, &CancellationReasonResponse{
+			ReasonID:    r.ReasonID,
+			Description: r.Description,
+			IsActive:    r.IsActive,
+		})
+	}
+
+	c.JSON(http.StatusOK, gin.H{"data": data})
+}
+
+// @Summary		Update a cancellation reason
+// @Description	Updates an existing cancellation reason's description and/or active status.
+// @Tags			Memberships
+// @Accept			json
+// @Produce		json
+// @Security		ApiKeyAuth
+// @Param			id		path		string							true	"Cancellation Reason UUID"
+// @Param			reason	body		UpdateCancellationReasonPayload	true	"Cancellation reason update payload"
+// @Success		200		{object}	CancellationReasonResponse		"Cancellation reason updated successfully"
+// @Failure		400		{object}	object{error=string}			"error: Bad Request - Invalid ID or payload"
+// @Failure		404		{object}	object{error=string}			"error: Not Found - Cancellation reason not found"
+// @Failure		409		{object}	object{error=string}			"error: Conflict - Description already exists"
+// @Failure		500		{object}	object{error=string}			"error: Internal Server Error"
+// @Router			/memberships/cancellation-reasons/{id} [put]
+func (h *MembershipHandler) UpdateCancellationReasonHandler(c *gin.Context) {
+	ctx := c.Request.Context()
+	var payload UpdateCancellationReasonPayload
+
+	reasonID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		h.services.LogErrors.BadRequestResponse(c, err)
+		return
+	}
+
+	if err := c.ShouldBindJSON(&payload); err != nil {
+		h.services.LogErrors.BadRequestResponse(c, err)
+		return
+	}
+
+	// Get existing reason
+	existingReason, err := h.services.MembershipServices.GetCancellationReasonByID(ctx, reasonID)
+	if err != nil {
+		switch err {
+		case shared_errors.ErrNotFound:
+			h.services.LogErrors.NotFoundResponse(c)
+		default:
+			h.services.LogErrors.InternalServerError(c, err)
+		}
+		return
+	}
+
+	// Update only provided fields
+	if payload.Description != "" {
+		existingReason.Description = payload.Description
+	}
+	if payload.IsActive != nil {
+		existingReason.IsActive = *payload.IsActive
+	}
+
+	if err := h.services.MembershipServices.UpdateCancellationReason(ctx, existingReason); err != nil {
+		switch err {
+		case shared_errors.ErrConflict:
+			h.services.LogErrors.ConflictResponse(c, err)
+		case shared_errors.ErrNotFound:
+			h.services.LogErrors.NotFoundResponse(c)
+		default:
+			h.services.LogErrors.InternalServerError(c, err)
+		}
+		return
+	}
+
+	resp := &CancellationReasonResponse{
+		ReasonID:    existingReason.ReasonID,
+		Description: existingReason.Description,
+		IsActive:    existingReason.IsActive,
+	}
+
+	c.JSON(http.StatusOK, resp)
+}
+
+// @Summary		Delete a cancellation reason
+// @Description	Soft deletes a cancellation reason by setting the deleted_at timestamp.
+// @Tags			Memberships
+// @Produce		json
+// @Security		ApiKeyAuth
+// @Param			id	path		string					true	"Cancellation Reason UUID"
+// @Success		204	{object}	nil						"No Content"
+// @Failure		400	{object}	object{error=string}	"error: Bad Request - Invalid ID"
+// @Failure		404	{object}	object{error=string}	"error: Not Found - Cancellation reason not found"
+// @Failure		500	{object}	object{error=string}	"error: Internal Server Error"
+// @Router			/memberships/cancellation-reasons/{id} [delete]
+func (h *MembershipHandler) DeleteCancellationReasonHandler(c *gin.Context) {
+	ctx := c.Request.Context()
+
+	reasonID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		h.services.LogErrors.BadRequestResponse(c, err)
+		return
+	}
+
+	if err := h.services.MembershipServices.DeleteCancellationReason(ctx, reasonID); err != nil {
+		switch err {
+		case shared_errors.ErrNotFound:
+			h.services.LogErrors.NotFoundResponse(c)
+		default:
+			h.services.LogErrors.InternalServerError(c, err)
+		}
+		return
+	}
+
+	c.JSON(http.StatusNoContent, nil)
+}

--- a/internal/modules/memberships/handlers/payload.go
+++ b/internal/modules/memberships/handlers/payload.go
@@ -79,3 +79,21 @@ type UpdateClientMembershipPayload struct {
 	CancelReasonID string `json:"cancel_reason_id"`
 	CancelNotes    string `json:"cancel_notes"`
 }
+
+// Cancellation Reasons Payloads
+
+type CreateCancellationReasonPayload struct {
+	Description string `json:"description" binding:"required"`
+	IsActive    bool   `json:"is_active"`
+}
+
+type UpdateCancellationReasonPayload struct {
+	Description string `json:"description"`
+	IsActive    *bool  `json:"is_active"`
+}
+
+type CancellationReasonResponse struct {
+	ReasonID    uuid.UUID `json:"reason_id"`
+	Description string    `json:"description"`
+	IsActive    bool      `json:"is_active"`
+}

--- a/internal/modules/memberships/handlers/routes.go
+++ b/internal/modules/memberships/handlers/routes.go
@@ -45,6 +45,17 @@ func (r *MembershipHandler) MembershipRoutes(rg *gin.RouterGroup, m *auth.AuthMi
 		clientMembershipsGroup.GET("/:clientMembershipId", m.RBACPermission("members:get"), r.GetClientMembershipByID)
 		clientMembershipsGroup.PUT("/:clientMembershipId", m.RBACPermission("members:update"), r.UpdateClientMembership)
 	}
+
+	// Cancellation Reasons routes
+	// Access: Super Admin exclusive
+	cancellationReasonsGroup := rg.Group("/memberships/cancellation-reasons")
+	{
+		cancellationReasonsGroup.Use(m.AuthJwtTokenMiddleware())
+		cancellationReasonsGroup.POST("", m.RBACPermission("cancellation-reasons:create"), r.CreateCancellationReasonHandler)
+		cancellationReasonsGroup.GET("", m.RBACPermission("cancellation-reasons:list"), r.GetCancellationReasonsHandler)
+		cancellationReasonsGroup.PUT("/:id", m.RBACPermission("cancellation-reasons:update"), r.UpdateCancellationReasonHandler)
+		cancellationReasonsGroup.DELETE("/:id", m.RBACPermission("cancellation-reasons:delete"), r.DeleteCancellationReasonHandler)
+	}
 }
 
 func (r *MembershipHandler) PublicMembershipRoutes(rg *gin.RouterGroup) {

--- a/internal/modules/memberships/repository/membership_repository.go
+++ b/internal/modules/memberships/repository/membership_repository.go
@@ -376,17 +376,12 @@ func (s *MembershipStore) UpdateCancellationReason(ctx context.Context, reason *
 
 func (s *MembershipStore) DeleteCancellationReason(ctx context.Context, id uuid.UUID) error {
 	// Soft delete - set deleted_at timestamp
-	err := s.db.WithContext(ctx).
-		Model(&membershipsdomain.CancellationReason{}).
-		Where("reason_id = ?", id).
-		Update("deleted_at", time.Now()).Error
-	if err != nil {
-		switch err {
-		case gorm.ErrRecordNotFound:
-			return shared_errors.ErrNotFound
-		default:
-			return err
-		}
+	result := s.db.WithContext(ctx).Delete(&membershipsdomain.CancellationReason{}, id)
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return shared_errors.ErrNotFound
 	}
 	return nil
 }
@@ -405,13 +400,33 @@ func (s *MembershipStore) GetCancellationReasonByID(ctx context.Context, id uuid
 	return reason, nil
 }
 
-func (s *MembershipStore) GetCancellationReasons(ctx context.Context) ([]*membershipsdomain.CancellationReason, error) {
+func (s *MembershipStore) GetCancellationReasons(ctx context.Context, fq pagination.PaginatedFeedQuery) ([]*membershipsdomain.CancellationReason, int64, error) {
 	var reasons []*membershipsdomain.CancellationReason
-	err := s.db.WithContext(ctx).Order("description ASC").Find(&reasons).Error
-	if err != nil {
-		return nil, err
+	var total int64
+
+	query := s.db.WithContext(ctx).Model(&membershipsdomain.CancellationReason{})
+
+	if fq.Search != "" {
+		query = query.Where("description ILIKE ?", "%"+fq.Search+"%")
 	}
-	return reasons, nil
+
+	if err := query.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	page := fq.Page
+	if page < 1 {
+		page = 1
+	}
+
+	err := query.Order("description " + fq.Sort).
+		Limit(fq.Limit).
+		Offset((page - 1) * fq.Limit).
+		Find(&reasons).Error
+	if err != nil {
+		return nil, 0, err
+	}
+	return reasons, total, nil
 }
 
 func (s *MembershipStore) GetCancellationReasonByDescription(ctx context.Context, description string) (*membershipsdomain.CancellationReason, error) {

--- a/internal/modules/memberships/repository/membership_repository.go
+++ b/internal/modules/memberships/repository/membership_repository.go
@@ -340,3 +340,90 @@ func (s *MembershipStore) GetAllMembershipTypes(ctx context.Context) ([]*members
 	return membershipTypes, nil
 
 }
+
+// Cancellation Reasons operations
+
+func (s *MembershipStore) CreateCancellationReason(ctx context.Context, reason *membershipsdomain.CancellationReason) error {
+	err := s.db.WithContext(ctx).Create(reason).Error
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) {
+			if pgErr.Code == "23505" { // unique_violation on description
+				return shared_errors.ErrConflict
+			}
+		}
+		return err
+	}
+	return nil
+}
+
+func (s *MembershipStore) UpdateCancellationReason(ctx context.Context, reason *membershipsdomain.CancellationReason) error {
+	err := s.db.WithContext(ctx).Save(reason).Error
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) {
+			if pgErr.Code == "23505" { // unique_violation on description
+				return shared_errors.ErrConflict
+			}
+		}
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return shared_errors.ErrNotFound
+		}
+		return err
+	}
+	return nil
+}
+
+func (s *MembershipStore) DeleteCancellationReason(ctx context.Context, id uuid.UUID) error {
+	// Soft delete - set deleted_at timestamp
+	err := s.db.WithContext(ctx).
+		Model(&membershipsdomain.CancellationReason{}).
+		Where("reason_id = ?", id).
+		Update("deleted_at", time.Now()).Error
+	if err != nil {
+		switch err {
+		case gorm.ErrRecordNotFound:
+			return shared_errors.ErrNotFound
+		default:
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *MembershipStore) GetCancellationReasonByID(ctx context.Context, id uuid.UUID) (*membershipsdomain.CancellationReason, error) {
+	reason := &membershipsdomain.CancellationReason{}
+	err := s.db.WithContext(ctx).Where("reason_id = ?", id).First(reason).Error
+	if err != nil {
+		switch err {
+		case gorm.ErrRecordNotFound:
+			return nil, shared_errors.ErrNotFound
+		default:
+			return nil, err
+		}
+	}
+	return reason, nil
+}
+
+func (s *MembershipStore) GetCancellationReasons(ctx context.Context) ([]*membershipsdomain.CancellationReason, error) {
+	var reasons []*membershipsdomain.CancellationReason
+	err := s.db.WithContext(ctx).Order("description ASC").Find(&reasons).Error
+	if err != nil {
+		return nil, err
+	}
+	return reasons, nil
+}
+
+func (s *MembershipStore) GetCancellationReasonByDescription(ctx context.Context, description string) (*membershipsdomain.CancellationReason, error) {
+	reason := &membershipsdomain.CancellationReason{}
+	err := s.db.WithContext(ctx).Where("description = ?", description).First(reason).Error
+	if err != nil {
+		switch err {
+		case gorm.ErrRecordNotFound:
+			return nil, shared_errors.ErrNotFound
+		default:
+			return nil, err
+		}
+	}
+	return reason, nil
+}

--- a/internal/modules/memberships/service/membership_services.go
+++ b/internal/modules/memberships/service/membership_services.go
@@ -126,6 +126,6 @@ func (s *MembershipService) GetCancellationReasonByID(ctx context.Context, id uu
 	return s.store.Membership.GetCancellationReasonByID(ctx, id)
 }
 
-func (s *MembershipService) GetCancellationReasons(ctx context.Context) ([]*membershipsdomain.CancellationReason, error) {
-	return s.store.Membership.GetCancellationReasons(ctx)
+func (s *MembershipService) GetCancellationReasons(ctx context.Context, fq pagination.PaginatedFeedQuery) ([]*membershipsdomain.CancellationReason, int64, error) {
+	return s.store.Membership.GetCancellationReasons(ctx, fq)
 }

--- a/internal/modules/memberships/service/membership_services.go
+++ b/internal/modules/memberships/service/membership_services.go
@@ -101,3 +101,31 @@ func (s *MembershipService) GetClientMembershipByID(ctx context.Context, clientM
 func (s *MembershipService) GetClientsMemberships(ctx context.Context, fq pagination.PaginatedFeedQuery) ([]*membershipsdomain.ClientMembership, int64, error) {
 	return s.store.Membership.GetClientsMemberships(ctx, fq)
 }
+
+// Cancellation Reasons operations
+
+func (s *MembershipService) CreateCancellationReason(ctx context.Context, reason *membershipsdomain.CancellationReason) error {
+	// Check if description already exists
+	existing, err := s.store.Membership.GetCancellationReasonByDescription(ctx, reason.Description)
+	if err == nil && existing != nil {
+		return err
+	}
+
+	return s.store.Membership.CreateCancellationReason(ctx, reason)
+}
+
+func (s *MembershipService) UpdateCancellationReason(ctx context.Context, reason *membershipsdomain.CancellationReason) error {
+	return s.store.Membership.UpdateCancellationReason(ctx, reason)
+}
+
+func (s *MembershipService) DeleteCancellationReason(ctx context.Context, id uuid.UUID) error {
+	return s.store.Membership.DeleteCancellationReason(ctx, id)
+}
+
+func (s *MembershipService) GetCancellationReasonByID(ctx context.Context, id uuid.UUID) (*membershipsdomain.CancellationReason, error) {
+	return s.store.Membership.GetCancellationReasonByID(ctx, id)
+}
+
+func (s *MembershipService) GetCancellationReasons(ctx context.Context) ([]*membershipsdomain.CancellationReason, error) {
+	return s.store.Membership.GetCancellationReasons(ctx)
+}


### PR DESCRIPTION
## Description
Implements complete CRUD API for managing standardized cancellation reasons for membership cancellations (API-CAT-09-01).

**Endpoints:**
- POST /v1/memberships/cancellation-reasons - Create new cancellation reason
- GET /v1/memberships/cancellation-reasons - List all cancellation reasons
- PUT /v1/memberships/cancellation-reasons/{id} - Update cancellation reason
- DELETE /v1/memberships/cancellation-reasons/{id} - Soft delete cancellation reason

**Implementation includes:**
- Repository layer with PostgreSQL error handling
- Service layer with business logic and duplicate prevention
- HTTP handlers with Swagger/OpenAPI documentation
- RBAC permissions (Super Admin exclusive)
- Database migration for soft delete support (created_at, updated_at, deleted_at)
- Request/response DTOs with validation

## Related Issue
Implements API-CAT-09-01: API para gestión de causales tipificadas de cancelación de membresías

## Motivation and Context
The system needed a way to track and manage standardized cancellation reasons for membership cancellations. This allows:
- Consistent categorization of cancellation reasons across the platform
- Historical tracking of why memberships are cancelled
- Data-driven insights into membership churn patterns
- Improved customer service through standardized responses

## How Has This Been Tested?
- POST endpoint: Created multiple cancellation reasons with unique descriptions
- GET endpoint: Retrieved all cancellation reasons ordered alphabetically
- PUT endpoint: Updated both description and is_active status
- DELETE endpoint: Verified soft delete sets deleted_at timestamp
- Duplicate prevention: Confirmed 409 Conflict returned for duplicate descriptions
- RBAC enforcement: Verified Super Admin permissions required for all operations
- Database migration: Successfully applied migration 000035
- Error handling: Tested invalid UUIDs, non-existent records, constraint violations

**Testing environment:**
- Local development with Docker Compose
- PostgreSQL database
- Postman for API endpoint testing
- Database queries to verify soft delete behavior

## Screenshots (if appropriate):
N/A - Backend API implementation only