### PR TITLE
refactor(permissions): Enforce branch_management for branch relations

### DIFF
--- a/internal/migrate/seed/data/permission.json
+++ b/internal/migrate/seed/data/permission.json
@@ -302,5 +302,9 @@
   {
     "name": "booking:schedule:list",
     "description": "Allows listing client schedules"
+  },
+  {
+    "name": "branch_management",
+    "description": "Allows management of branch operations"
   }
 ]

--- a/internal/migrate/seed/data/permission_set.json
+++ b/internal/migrate/seed/data/permission_set.json
@@ -46,7 +46,8 @@
     "cancellation-reasons:list",
     "cancellation-reasons:update",
     "cancellation-reasons:delete",
-    "access:check_in"
+    "access:check_in",
+    "branch_management"
   ],
   "recepcionist": [
     "users:create",

--- a/internal/migrate/seed/data/policies.json
+++ b/internal/migrate/seed/data/policies.json
@@ -1,8 +1,8 @@
 [
   {
     "policy_key": "INVOICE_OVERDUE_TIME_DAYS",
-    "display_name": "Tiempo de Vencimiento de Factura",
-    "description": "Días permitidos antes de considerar una factura como vencida.",
+    "display_name": "Invoice Overdue Time",
+    "description": "Days allowed before considering an invoice as overdue.",
     "value": "3",
     "data_type": "INTEGER",
     "min_limit": 0,
@@ -11,8 +11,8 @@
   },
   {
     "policy_key": "CLASS_CANCEL_MIN_HOURS",
-    "display_name": "Antelación Cancelación de Clases",
-    "description": "Horas mínimas de antelación requeridas para cancelar una clase sin penalización.",
+    "display_name": "Class Cancellation Notice",
+    "description": "Minimum hours of notice required to cancel a class without penalty.",
     "value": "2",
     "data_type": "INTEGER",
     "min_limit": 0,
@@ -21,8 +21,8 @@
   },
   {
     "policy_key": "ACCESS_WINDOW_BEFORE_CLASS",
-    "display_name": "Ventana de Acceso Pre-Clase",
-    "description": "Minutos antes del inicio de la clase permitidos para ingresar a las instalaciones.",
+    "display_name": "Pre-Class Access Window",
+    "description": "Minutes before the start of the class allowed to enter the facilities.",
     "value": "15",
     "data_type": "INTEGER",
     "min_limit": 0,
@@ -31,8 +31,8 @@
   },
   {
     "policy_key": "MEMBERSHIP_GRACE_PERIOD_DAYS",
-    "display_name": "Días de Gracia Membresía",
-    "description": "Días de acceso permitido tras el vencimiento de la membresía antes de bloquear el acceso.",
+    "display_name": "Membership Grace Period",
+    "description": "Days of access allowed after membership expiration before blocking access.",
     "value": "2",
     "data_type": "INTEGER",
     "min_limit": 0,
@@ -41,8 +41,8 @@
   },
   {
     "policy_key": "GLOBAL_MAX_DISCOUNT",
-    "display_name": "Descuento Máximo Global",
-    "description": "Porcentaje máximo de descuento que se puede aplicar manualmente a una venta.",
+    "display_name": "Global Max Discount",
+    "description": "Maximum percentage discount that can be manually applied to a sale.",
     "value": "20.00",
     "data_type": "PERCENTAGE",
     "min_limit": 0.00,

--- a/internal/modules/billing/handlers/routes.go
+++ b/internal/modules/billing/handlers/routes.go
@@ -71,10 +71,10 @@ func (r *BillingHandlers) BillingRoutes(rg *gin.RouterGroup, m *auth.AuthMiddlew
 	branchPaymentMethodsGroup.Use(m.AuthJwtTokenMiddleware())
 	{
 		branchPaymentMethodsGroup.GET("", r.GetPaymentMethodsFromBranchHandler)
-		branchPaymentMethodsGroup.POST("", m.RBACPermission("billing:create"), r.AddPaymentMethodsToBranchHandler)
+		branchPaymentMethodsGroup.POST("", m.RBACPermission("branch_management"), r.AddPaymentMethodsToBranchHandler)
 		branchPaymentMethodsGroup.GET("/:method_id", r.GetBranchPaymentMethodByIDHandler)
-		branchPaymentMethodsGroup.PUT("/:method_id", m.RBACPermission("billing:update"), r.UpdatePaymentMethodFromBranchHandler)
-		branchPaymentMethodsGroup.DELETE("/:method_id", m.RBACPermission("billing:delete"), r.DeletePaymentMethodsFromBranchHandler)
+		branchPaymentMethodsGroup.PUT("/:method_id", m.RBACPermission("branch_management"), r.UpdatePaymentMethodFromBranchHandler)
+		branchPaymentMethodsGroup.DELETE("/:method_id", m.RBACPermission("branch_management"), r.DeletePaymentMethodsFromBranchHandler)
 	}
 
 	fiscalDocumentTypesGroup := billingGroup.Group("/fiscal-document-types")

--- a/internal/modules/instructor/handler/routes.go
+++ b/internal/modules/instructor/handler/routes.go
@@ -46,8 +46,8 @@ func (r *InstructorHandlers) InstructorRoutes(rg *gin.RouterGroup, m *auth.AuthM
 
 	branchInstructorGroup := rg.Group("/branches/:id/instructor").Use(m.AuthJwtTokenMiddleware())
 	{
-		branchInstructorGroup.POST("", m.RBACPermission("instructors:create"), r.AssignInstructorsToBranchHandler)
+		branchInstructorGroup.POST("", m.RBACPermission("branch_management"), r.AssignInstructorsToBranchHandler)
 		branchInstructorGroup.GET("", m.RBACPermission("instructors:list"), r.ListBranchInstructorsHandler)
-		branchInstructorGroup.DELETE("/:instructor_id", m.RBACPermission("instructors:delete"), r.RemoveInstructorFromBranchHandler)
+		branchInstructorGroup.DELETE("/:instructor_id", m.RBACPermission("branch_management"), r.RemoveInstructorFromBranchHandler)
 	}
 }

--- a/internal/modules/inventory/handlers/routes.go
+++ b/internal/modules/inventory/handlers/routes.go
@@ -55,10 +55,10 @@ func (r *InventoryHandlers) InventoryRoutes(rg *gin.RouterGroup, m *auth.AuthMid
 		Use(m.AuthJwtTokenMiddleware())
 
 	{
-		branchInventoryGroup.POST("", r.AddInventoryItemHandler)
-		branchInventoryGroup.GET("", r.ListBranchInventoryHandler)
-		branchInventoryGroup.GET("/:inventoryId", r.GetInventoryByID)
-		branchInventoryGroup.PATCH("/:inventoryId", r.UpdateInventoryItemHandler)
-		branchInventoryGroup.DELETE("/:inventoryId", r.DeleteInventoryItemHandler)
+		branchInventoryGroup.POST("", m.RBACPermission("branch_management"), r.AddInventoryItemHandler)
+		branchInventoryGroup.GET("", m.RBACPermission("branch_management"), r.ListBranchInventoryHandler)
+		branchInventoryGroup.GET("/:inventoryId", m.RBACPermission("branch_management"), r.GetInventoryByID)
+		branchInventoryGroup.PATCH("/:inventoryId", m.RBACPermission("branch_management"), r.UpdateInventoryItemHandler)
+		branchInventoryGroup.DELETE("/:inventoryId", m.RBACPermission("branch_management"), r.DeleteInventoryItemHandler)
 	}
 }

--- a/internal/modules/products/handler/routes.go
+++ b/internal/modules/products/handler/routes.go
@@ -53,11 +53,11 @@ func (r *ProductsHandler) ProductsRoutes(rg *gin.RouterGroup, m *auth.AuthMiddle
 	BranchServicesGroup := rg.Group("/branches/:id/services")
 	{
 		BranchServicesGroup.Use(m.AuthJwtTokenMiddleware())
-		BranchServicesGroup.POST("", m.RBACPermission("services:create"), r.AssignBranchServiceHandler)
-		BranchServicesGroup.GET("", m.RBACPermission("services:list"), r.GetBranchServiceHandler)
-		BranchServicesGroup.GET("/:service_id", m.RBACPermission("services:get"), r.GetBranchServiceByIDHandler)
-		BranchServicesGroup.PUT("/:service_id", m.RBACPermission("services:update"), r.UpdateBranchServiceHandler)
-		BranchServicesGroup.DELETE("/:service_id", m.RBACPermission("services:delete"), r.DeleteBranchServiceHandler)
+		BranchServicesGroup.POST("", m.RBACPermission("branch_management"), r.AssignBranchServiceHandler)
+		BranchServicesGroup.GET("", m.RBACPermission("branch_management"), r.GetBranchServiceHandler)
+		BranchServicesGroup.GET("/:service_id", m.RBACPermission("branch_management"), r.GetBranchServiceByIDHandler)
+		BranchServicesGroup.PUT("/:service_id", m.RBACPermission("branch_management"), r.UpdateBranchServiceHandler)
+		BranchServicesGroup.DELETE("/:service_id", m.RBACPermission("branch_management"), r.DeleteBranchServiceHandler)
 	}
 }
 

--- a/internal/modules/staff/handlers/routes.go
+++ b/internal/modules/staff/handlers/routes.go
@@ -28,9 +28,9 @@ func (h *StaffHandlers) StaffRoutes(rg *gin.RouterGroup, m *auth.AuthMiddleware)
 	staffRoutes := rg.Group("/branches/:id/staff")
 	{
 		staffRoutes.Use(m.AuthJwtTokenMiddleware())
-		staffRoutes.POST("", m.RBACPermission("users:update"), h.AssignStaffToBranchHandler)
-		staffRoutes.GET("", m.RBACPermission("users:list"), h.ListBranchStaffByRoleHandler)
-		staffRoutes.DELETE("/:staffId", m.RBACPermission("users:update"), h.RemoveStaffFromBranchHandler)
+		staffRoutes.POST("", m.RBACPermission("branch_management"), h.AssignStaffToBranchHandler)
+		staffRoutes.GET("", m.RBACPermission("branch_management"), h.ListBranchStaffByRoleHandler)
+		staffRoutes.DELETE("/:staffId", m.RBACPermission("branch_management"), h.RemoveStaffFromBranchHandler)
 	}
 
 	staffMemberRoutes := rg.Group("/staff")


### PR DESCRIPTION
### Description

This PR refactors the route protection logic for Branch Relations.

    Updated the permission requirement for Assigning, Listing, and Removing entities related to a branch.

    These routes now strictly require the branch_management permission node instead of the previous generic or incorrect permission.

### Related Issue

N/A
### Motivation and Context

Security & Consistency: Previous permission checks were inconsistent or too broad. By standardizing on branch_management, we ensure that only authorized Branch Admins can modify the composition of their branch (e.g., staff assignment, resource management). This tightens the Role-Based Access Control (RBAC).
How Has This Been Tested?

    Negative Test (403 Forbidden): Attempted to list/assign branch relations using a user account without the branch_management permission. Verified that the request was denied.

    Positive Test (200 OK): Attempted the same actions using a user with the branch_management permission. Verified the request succeeded.