### PR TITLE
feat(schedule): Implement Class Recurrence & Client Schedule Filtering

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -15652,6 +15652,17 @@ const docTemplate = `{
                 "notes": {
                     "type": "string"
                 },
+                "recurrence": {
+                    "type": "string",
+                    "enum": [
+                        "daily",
+                        "weekly",
+                        "none"
+                    ]
+                },
+                "recurrence_until": {
+                    "type": "string"
+                },
                 "service_id": {
                     "type": "string"
                 },

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -7844,6 +7844,168 @@ const docTemplate = `{
                 }
             }
         },
+        "/policies": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Retrieves a list of all commercial policies.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Policies"
+                ],
+                "summary": "List all policies",
+                "responses": {
+                    "200": {
+                        "description": "List of policies",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/policieshandler.PolicyResponse"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/policies/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Retrieves detailed information about a specific policy by its UUID.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Policies"
+                ],
+                "summary": "Get policy by ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Policy UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Policy details",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "$ref": "#/definitions/policieshandler.PolicyResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request: Invalid UUID format",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found: Policy not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Updates an existing policy's value.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Policies"
+                ],
+                "summary": "Update a policy",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Policy UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Payload with value to update",
+                        "name": "policy",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/policieshandler.UpdatePolicyValue"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Policy updated successfully"
+                    },
+                    "400": {
+                        "description": "Bad Request: Invalid UUID or payload",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found: Policy not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/public/branches-map": {
             "get": {
                 "description": "Retrieves a list of public branches with minimal information for map display.",
@@ -14623,6 +14785,40 @@ const docTemplate = `{
                 },
                 "price": {
                     "type": "number"
+                }
+            }
+        },
+        "policieshandler.PolicyResponse": {
+            "type": "object",
+            "properties": {
+                "active": {
+                    "type": "boolean"
+                },
+                "category": {
+                    "type": "string"
+                },
+                "data_type": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                }
+            }
+        },
+        "policieshandler.UpdatePolicyValue": {
+            "type": "object",
+            "properties": {
+                "value": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -7836,6 +7836,168 @@
                 }
             }
         },
+        "/policies": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Retrieves a list of all commercial policies.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Policies"
+                ],
+                "summary": "List all policies",
+                "responses": {
+                    "200": {
+                        "description": "List of policies",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/policieshandler.PolicyResponse"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/policies/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Retrieves detailed information about a specific policy by its UUID.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Policies"
+                ],
+                "summary": "Get policy by ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Policy UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Policy details",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "$ref": "#/definitions/policieshandler.PolicyResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request: Invalid UUID format",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found: Policy not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Updates an existing policy's value.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Policies"
+                ],
+                "summary": "Update a policy",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Policy UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Payload with value to update",
+                        "name": "policy",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/policieshandler.UpdatePolicyValue"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Policy updated successfully"
+                    },
+                    "400": {
+                        "description": "Bad Request: Invalid UUID or payload",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found: Policy not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/public/branches-map": {
             "get": {
                 "description": "Retrieves a list of public branches with minimal information for map display.",
@@ -14615,6 +14777,40 @@
                 },
                 "price": {
                     "type": "number"
+                }
+            }
+        },
+        "policieshandler.PolicyResponse": {
+            "type": "object",
+            "properties": {
+                "active": {
+                    "type": "boolean"
+                },
+                "category": {
+                    "type": "string"
+                },
+                "data_type": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                }
+            }
+        },
+        "policieshandler.UpdatePolicyValue": {
+            "type": "object",
+            "properties": {
+                "value": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -15644,6 +15644,17 @@
                 "notes": {
                     "type": "string"
                 },
+                "recurrence": {
+                    "type": "string",
+                    "enum": [
+                        "daily",
+                        "weekly",
+                        "none"
+                    ]
+                },
+                "recurrence_until": {
+                    "type": "string"
+                },
                 "service_id": {
                     "type": "string"
                 },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1769,6 +1769,28 @@ definitions:
       price:
         type: number
     type: object
+  policieshandler.PolicyResponse:
+    properties:
+      active:
+        type: boolean
+      category:
+        type: string
+      data_type:
+        type: string
+      description:
+        type: string
+      id:
+        type: string
+      name:
+        type: string
+      value:
+        type: string
+    type: object
+  policieshandler.UpdatePolicyValue:
+    properties:
+      value:
+        type: string
+    type: object
   productsdomain.Service:
     properties:
       banners:
@@ -7511,6 +7533,111 @@ paths:
       summary: Update a package
       tags:
       - Packages
+  /policies:
+    get:
+      description: Retrieves a list of all commercial policies.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: List of policies
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/definitions/policieshandler.PolicyResponse'
+                type: array
+            type: object
+        "500":
+          description: Internal server error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - ApiKeyAuth: []
+      summary: List all policies
+      tags:
+      - Policies
+  /policies/{id}:
+    get:
+      description: Retrieves detailed information about a specific policy by its UUID.
+      parameters:
+      - description: Policy UUID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Policy details
+          schema:
+            properties:
+              data:
+                $ref: '#/definitions/policieshandler.PolicyResponse'
+            type: object
+        "400":
+          description: 'Bad Request: Invalid UUID format'
+          schema:
+            additionalProperties: true
+            type: object
+        "404":
+          description: 'Not Found: Policy not found'
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - ApiKeyAuth: []
+      summary: Get policy by ID
+      tags:
+      - Policies
+    put:
+      consumes:
+      - application/json
+      description: Updates an existing policy's value.
+      parameters:
+      - description: Policy UUID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Payload with value to update
+        in: body
+        name: policy
+        required: true
+        schema:
+          $ref: '#/definitions/policieshandler.UpdatePolicyValue'
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: Policy updated successfully
+        "400":
+          description: 'Bad Request: Invalid UUID or payload'
+          schema:
+            additionalProperties: true
+            type: object
+        "404":
+          description: 'Not Found: Policy not found'
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - ApiKeyAuth: []
+      summary: Update a policy
+      tags:
+      - Policies
   /public/branches-map:
     get:
       description: Retrieves a list of public branches with minimal information for

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2340,6 +2340,14 @@ definitions:
         type: integer
       notes:
         type: string
+      recurrence:
+        enum:
+        - daily
+        - weekly
+        - none
+        type: string
+      recurrence_until:
+        type: string
       service_id:
         type: string
       starts_at:

--- a/internal/migrate/seed/main.go
+++ b/internal/migrate/seed/main.go
@@ -159,8 +159,8 @@ func (s *SeedStruct) SeedPermissions(store store.Storage, db *gorm.DB, ctx conte
 }
 
 func randomDateInLastSixMonths() time.Time {
-	now := time.Now()
-	sixMonthsAgo := now.AddDate(0, -6, 0)
+	now := time.Now().AddDate(0, 1, 0)
+	sixMonthsAgo := now.AddDate(0, -1, 0)
 
 	duration := now.Sub(sixMonthsAgo)
 	randomDuration := time.Duration(rand.Int63n(int64(duration)))
@@ -185,26 +185,23 @@ func (s *SeedStruct) SeedRolePermissions(store store.Storage, db *gorm.DB, ctx c
 
 	err = db.Transaction(func(tx *gorm.DB) error {
 		for roleName, permissionNames := range permissionSet {
-			// Obtener el rol por nombre
 			role, err := store.Roles.GetByName(ctx, roleName)
 			if err != nil {
 				log.Printf("Error getting role '%s': %v. Skipping...", roleName, err)
-				continue // O puedes retornar el error si es crítico
+				continue
 			}
 
 			var permissionIDs []uuid.UUID
 			for _, permName := range permissionNames {
-				// Obtener el permiso por nombre
 				permission, err := store.Roles.GetPermissionByName(ctx, permName)
 				if err != nil {
 					log.Printf("Error getting permission '%s' for role '%s': %v. Skipping permission...", permName, roleName, err)
-					continue // O puedes retornar el error
+					continue
 				}
 				permissionIDs = append(permissionIDs, permission.PermissionID)
 			}
 
 			if len(permissionIDs) > 0 {
-				// Asignar los permisos al rol
 				err := store.Roles.AssignRolePermission(ctx, role.RoleID, permissionIDs)
 				if err != nil {
 					log.Printf("Error assigning permissions to role '%s': %v", roleName, err)
@@ -390,7 +387,7 @@ func (s *SeedStruct) SeedInstructors(store store.Storage, db *gorm.DB, ctx conte
 			user.RoleID = role.RoleID
 
 			// Asignar especialidades aleatorias
-			numSpecialtiesToAssign := r.Intn(len(specialties)) + 1 // Asignar de 1 a len(specialties)
+			numSpecialtiesToAssign := r.Intn(len(specialties)) + 1
 			r.Shuffle(len(specialties), func(i, j int) {
 				specialties[i], specialties[j] = specialties[j], specialties[i]
 			})
@@ -842,14 +839,13 @@ func (s *SeedStruct) SeedPackages(store store.Storage, db *gorm.DB, ctx context.
 				CreatedAt:   randomDateInLastSixMonths(),
 			}
 
-			// Generar items de paquete aleatorios
-			numItems := rand.Intn(3) + 2 // Entre 2 y 4 servicios por paquete
+			numItems := rand.Intn(3) + 2
 			rand.Shuffle(len(allServices), func(i, j int) {
 				allServices[i], allServices[j] = allServices[j], allServices[i]
 			})
 
 			for i := 0; i < numItems && i < len(allServices); i++ {
-				sessions := rand.Intn(16) + 5 // Entre 5 y 20 sesiones
+				sessions := rand.Intn(16) + 5
 				pkg.PackageItems = append(pkg.PackageItems, combosdomain.PackageItem{
 					ServiceID:        allServices[i].ServiceID,
 					SessionsIncluded: sessions,
@@ -875,7 +871,6 @@ func (s *SeedStruct) SeedPackages(store store.Storage, db *gorm.DB, ctx context.
 func (s *SeedStruct) SeedBranchRelations(store store.Storage, db *gorm.DB, ctx context.Context) {
 	log.Println("Starting to seed branch relations...")
 
-	// 1. Obtener todos los datos maestros
 	allBranches, err := store.Branches.GetAllBranches(ctx)
 	if err != nil || len(allBranches) == 0 {
 		log.Fatalf("Fatal error: could not get branches or no branches found: %v", err)
@@ -902,14 +897,12 @@ func (s *SeedStruct) SeedBranchRelations(store store.Storage, db *gorm.DB, ctx c
 		log.Println("Warning: No payment methods found. Skipping payment-branch relations.")
 	}
 
-	// 2. Iterar sobre cada sucursal y asignar relaciones
 	for _, branch := range allBranches {
 		log.Printf("Processing relations for branch: %s", branch.Name)
 
 		err := db.Transaction(func(tx *gorm.DB) error {
-			// Asignar Servicios
 			if len(allServices) > 0 {
-				numServices := rand.Intn(len(allServices)/2) + 5 // Asignar entre 5 y la mitad de los servicios
+				numServices := rand.Intn(len(allServices)/2) + 5
 				rand.Shuffle(len(allServices), func(i, j int) { allServices[i], allServices[j] = allServices[j], allServices[i] })
 
 				var branchServices []*productsdomain.ServiceBranchDetail
@@ -930,9 +923,8 @@ func (s *SeedStruct) SeedBranchRelations(store store.Storage, db *gorm.DB, ctx c
 				log.Printf(" -> Assigned %d services to %s", len(branchServices), branch.Name)
 			}
 
-			// Asignar Instructores
 			if len(allInstructors) > 0 {
-				numInstructors := rand.Intn(len(allInstructors)/2) + 2 // Asignar entre 2 y la mitad de los instructores
+				numInstructors := rand.Intn(len(allInstructors)/2) + 2
 				rand.Shuffle(len(allInstructors), func(i, j int) { allInstructors[i], allInstructors[j] = allInstructors[j], allInstructors[i] })
 
 				var instructorIDs []uuid.UUID
@@ -945,9 +937,8 @@ func (s *SeedStruct) SeedBranchRelations(store store.Storage, db *gorm.DB, ctx c
 				log.Printf(" -> Assigned %d instructors to %s", len(instructorIDs), branch.Name)
 			}
 
-			// Asignar Equipamiento
 			if len(allEquipment) > 0 {
-				numEquipment := rand.Intn(20) + 10 // Asignar entre 10 y 29 items de equipamiento
+				numEquipment := rand.Intn(20) + 10
 				for i := 0; i < numEquipment; i++ {
 					equipment := allEquipment[rand.Intn(len(allEquipment))]
 					inventoryItem := &inventorydomain.BranchInventory{
@@ -955,21 +946,19 @@ func (s *SeedStruct) SeedBranchRelations(store store.Storage, db *gorm.DB, ctx c
 						EquipmentID:     equipment.EquipmentID,
 						SerialNumber:    fmt.Sprintf("SN-%s-%d", equipment.Model, rand.Intn(99999)),
 						Status:          inventorydomain.EquipmentAvailable,
-						AcquisitionDate: &time.Time{}, // Puedes poner una fecha random si quieres
+						AcquisitionDate: &time.Time{},
 						Notes:           "Seeded item",
 						CreatedAt:       randomDateInLastSixMonths(),
 					}
 					if _, err := store.BranchInventory.Create(ctx, inventoryItem); err != nil {
-						// No retornamos error para no parar el seeder por un serial number duplicado
 						log.Printf("Could not create inventory item for branch %s: %v", branch.Name, err)
 					}
 				}
 				log.Printf(" -> Assigned %d equipment items to %s", numEquipment, branch.Name)
 			}
 
-			// Asignar Métodos de Pago
 			if len(allPaymentMethods) > 0 {
-				numMethods := rand.Intn(len(allPaymentMethods)) + 1 // Asignar al menos 1
+				numMethods := rand.Intn(len(allPaymentMethods)) + 1
 				rand.Shuffle(len(allPaymentMethods), func(i, j int) {
 					allPaymentMethods[i], allPaymentMethods[j] = allPaymentMethods[j], allPaymentMethods[i]
 				})
@@ -1031,7 +1020,7 @@ func (s *SeedStruct) SeedClasses(store store.Storage, db *gorm.DB, ctx context.C
 		}
 
 		for d := startDate; d.Before(endDate); d = d.AddDate(0, 0, 1) {
-			numClassesToday := rand.Intn(4) + 2 // Entre 2 y 5 clases por día
+			numClassesToday := rand.Intn(4) + 2
 
 			rand.Shuffle(len(openingHours), func(i, j int) {
 				openingHours[i], openingHours[j] = openingHours[j], openingHours[i]
@@ -1040,7 +1029,7 @@ func (s *SeedStruct) SeedClasses(store store.Storage, db *gorm.DB, ctx context.C
 			for i := 0; i < numClassesToday; i++ {
 				randomServiceDetail := branchServices[rand.Intn(len(branchServices))]
 				randomInstructor := branchInstructors[rand.Intn(len(branchInstructors))]
-				startHour := openingHours[i%len(openingHours)] // Usar módulo para evitar index out of bounds
+				startHour := openingHours[i%len(openingHours)]
 				startMinute := []int{0, 15, 30, 45}[rand.Intn(4)]
 
 				startTime := time.Date(d.Year(), d.Month(), d.Day(), startHour, startMinute, 0, 0, d.Location())
@@ -1088,7 +1077,6 @@ func (s *SeedStruct) SeedClasses(store store.Storage, db *gorm.DB, ctx context.C
 func (s *SeedStruct) SeedBookingsAndAttendance(store store.Storage, db *gorm.DB, ctx context.Context) {
 	log.Println("Starting to seed bookings and attendance...")
 
-	// 1. Obtener datos maestros
 	allBranches, err := store.Branches.GetAllBranches(ctx)
 	if err != nil || len(allBranches) == 0 {
 		log.Fatalf("Fatal: Could not get branches or no branches found: %v", err)
@@ -1100,12 +1088,10 @@ func (s *SeedStruct) SeedBookingsAndAttendance(store store.Storage, db *gorm.DB,
 		return
 	}
 
-	// Contenedores para inserción en lotes
 	var bookingsToCreate []bookingdomain.Booking
 	var attendanceToCreate []accessdomain.AttendanceLog
 	now := time.Now()
 
-	// 2. Iterar por cada SUCURSAL para obtener sus clases
 	for _, branch := range allBranches {
 		log.Printf("Processing bookings for branch: %s", branch.Name)
 
@@ -1115,15 +1101,12 @@ func (s *SeedStruct) SeedBookingsAndAttendance(store store.Storage, db *gorm.DB,
 			continue
 		}
 
-		// 3. Iterar sobre cada clase de la sucursal
 		for _, class := range branchClasses {
-			// Omitir "Open Gym"
 			if class.Service.Name == "Open Gym" {
 				continue
 			}
 
-			// Decidir aleatoriamente cuántos clientes reservarán la clase
-			minBookings := int(float64(class.MaxCapacity) * 0.4) // Al menos el 40%
+			minBookings := int(float64(class.MaxCapacity) * 0.4)
 			maxBookings := class.MaxCapacity
 			if minBookings > maxBookings {
 				minBookings = maxBookings
@@ -1139,13 +1122,11 @@ func (s *SeedStruct) SeedBookingsAndAttendance(store store.Storage, db *gorm.DB,
 				numBookings = maxBookings
 			}
 
-			// Seleccionar clientes aleatorios para la clase
 			rand.Shuffle(len(allClients), func(i, j int) { allClients[i], allClients[j] = allClients[j], allClients[i] })
 
 			for i := 0; i < numBookings && i < len(allClients); i++ {
 				client := allClients[i]
 
-				// 4. Crear la reserva (Booking)
 				bookingDate := class.StartsAt.Add(-time.Hour * time.Duration(rand.Intn(48)+1)) // Reservado 1-48h antes
 				booking := bookingdomain.Booking{
 					UserID:    client.UserID,
@@ -1156,22 +1137,21 @@ func (s *SeedStruct) SeedBookingsAndAttendance(store store.Storage, db *gorm.DB,
 				}
 				bookingsToCreate = append(bookingsToCreate, booking)
 
-				// 5. Si la clase ya pasó, simular la asistencia
 				if class.StartsAt.Before(now) {
-					attended := rand.Intn(100) < 85 // 85% de probabilidad de asistir
+					attended := rand.Intn(100) < 85
 
 					attendance := accessdomain.AttendanceLog{
 						UserID:    client.UserID,
 						ClassID:   &class.ClassID,
-						ServiceID: class.ServiceID, // Añadir el ServiceID de la clase
+						ServiceID: class.ServiceID,
 					}
 
 					if attended {
-						checkInOffset := time.Duration(rand.Intn(30)-15) * time.Minute // +/- 15 minutos
-						attendance.CheckInTime = class.StartsAt.Add(checkInOffset)     // Corregido: Usar la variable correcta
+						checkInOffset := time.Duration(rand.Intn(30)-15) * time.Minute
+						attendance.CheckInTime = class.StartsAt.Add(checkInOffset)
 						attendance.Status = accessdomain.AttendanceStatusAttended
 					} else {
-						attendance.CheckInTime = class.StartsAt // Para no-shows, la hora es la de la clase
+						attendance.CheckInTime = class.StartsAt
 						attendance.Status = accessdomain.AttendanceStatusNoShow
 					}
 					attendance.CreatedAt = attendance.CheckInTime
@@ -1181,7 +1161,6 @@ func (s *SeedStruct) SeedBookingsAndAttendance(store store.Storage, db *gorm.DB,
 		}
 	}
 
-	// 6. Insertar en lotes
 	log.Printf("Generated %d bookings and %d attendance logs. Inserting into database...", len(bookingsToCreate), len(attendanceToCreate))
 	if err := db.CreateInBatches(&bookingsToCreate, 1000).Error; err != nil {
 		log.Fatalf("Fatal error during bookings batch insert: %v", err)
@@ -1206,6 +1185,15 @@ func (s *SeedStruct) SeedInvoicesAndPayments(store store.Storage, db *gorm.DB, c
 	if err != nil || len(allBranches) == 0 {
 		log.Fatalf("Fatal: Could not get branches or no branches found: %v", err)
 		return
+	}
+
+	allValidPaymentMethods, err := store.PaymentMethods.GetPaymentMethods(ctx)
+	if err != nil {
+		log.Printf("Warning: Could not get payment methods: %v", err)
+	}
+	validPaymentMethodIDs := make(map[uuid.UUID]bool)
+	for _, pm := range allValidPaymentMethods {
+		validPaymentMethodIDs[pm.MethodID] = true
 	}
 
 	membershipTypes, err := store.Membership.GetAllMembershipTypes(ctx)
@@ -1285,8 +1273,16 @@ func (s *SeedStruct) SeedInvoicesAndPayments(store store.Storage, db *gorm.DB, c
 			})
 
 			branchPaymentMethods, _ := store.PaymentMethods.GetPaymentMethodsFromBranch(ctx, branch.BranchID)
-			if len(branchPaymentMethods) == 0 {
-				log.Printf("Warning: No payment methods for branch %s. Cannot simulate payment for invoice %s", branch.Name, invoice.InvoiceID)
+
+			var validBranchMethods []*billingdomain.PaymentMethodsBranch
+			for _, bpm := range branchPaymentMethods {
+				if validPaymentMethodIDs[bpm.MethodID] {
+					validBranchMethods = append(validBranchMethods, bpm)
+				}
+			}
+
+			if len(validBranchMethods) == 0 {
+				log.Printf("Warning: No valid payment methods for branch %s. Cannot simulate payment for invoice %s", branch.Name, invoice.InvoiceID)
 				continue
 			}
 
@@ -1294,7 +1290,7 @@ func (s *SeedStruct) SeedInvoicesAndPayments(store store.Storage, db *gorm.DB, c
 			remainingAmount := invoice.TotalAmount
 
 			for p := 0; p < numPayments && remainingAmount.IsPositive(); p++ {
-				paymentMethod := branchPaymentMethods[rand.Intn(len(branchPaymentMethods))]
+				paymentMethod := validBranchMethods[rand.Intn(len(validBranchMethods))]
 				amountToPay := remainingAmount
 				if numPayments > 1 && p < numPayments-1 {
 					amountToPay = remainingAmount.Div(decimal.NewFromInt(2))

--- a/internal/modules/policies/domain/repository.go
+++ b/internal/modules/policies/domain/repository.go
@@ -2,9 +2,12 @@ package policiesdomain
 
 import (
 	"context"
+
+	"gorm.io/gorm"
 )
 
 type PoliciesRepository interface {
+	CreatePolicyTx(ctx context.Context, tx *gorm.DB, policy *CommercialPolicy) error
 	CreatePolicy(ctx context.Context, policy *CommercialPolicy) error
 	GetPolicyByKey(ctx context.Context, key string) (*CommercialPolicy, error)
 	UpdatePolicy(ctx context.Context, policy *CommercialPolicy) error

--- a/internal/modules/policies/domain/repository.go
+++ b/internal/modules/policies/domain/repository.go
@@ -2,11 +2,10 @@ package policiesdomain
 
 import (
 	"context"
-
-	"gorm.io/gorm"
 )
 
 type PoliciesRepository interface {
-	CreatePolicyTx(ctx context.Context, tx *gorm.DB, policy *CommercialPolicy) error
 	CreatePolicy(ctx context.Context, policy *CommercialPolicy) error
+	GetPolicyByKey(ctx context.Context, key string) (*CommercialPolicy, error)
+	UpdatePolicy(ctx context.Context, policy *CommercialPolicy) error
 }

--- a/internal/modules/policies/domain/repository.go
+++ b/internal/modules/policies/domain/repository.go
@@ -8,4 +8,5 @@ type PoliciesRepository interface {
 	CreatePolicy(ctx context.Context, policy *CommercialPolicy) error
 	GetPolicyByKey(ctx context.Context, key string) (*CommercialPolicy, error)
 	UpdatePolicy(ctx context.Context, policy *CommercialPolicy) error
+	GetPoliciesList(ctx context.Context, policy *CommercialPolicy) ([]CommercialPolicy, error)
 }

--- a/internal/modules/policies/domain/repository.go
+++ b/internal/modules/policies/domain/repository.go
@@ -3,6 +3,7 @@ package policiesdomain
 import (
 	"context"
 
+	"github.com/google/uuid"
 	"gorm.io/gorm"
 )
 
@@ -12,4 +13,5 @@ type PoliciesRepository interface {
 	GetPolicyByKey(ctx context.Context, key string) (*CommercialPolicy, error)
 	UpdatePolicy(ctx context.Context, policy *CommercialPolicy) error
 	GetPoliciesList(ctx context.Context, policy *CommercialPolicy) ([]CommercialPolicy, error)
+	GetPolicyByID(ctx context.Context, policyID uuid.UUID) (*CommercialPolicy, error)
 }

--- a/internal/modules/policies/domain/services.go
+++ b/internal/modules/policies/domain/services.go
@@ -1,3 +1,10 @@
 package policiesdomain
 
-type PoliciesServicesInterface interface{}
+import "context"
+
+type PoliciesServicesInterface interface {
+	CreatePolicy(ctx context.Context, policy *CommercialPolicy) error
+	GetPolicyByKey(ctx context.Context, key string) (*CommercialPolicy, error)
+	UpdatePolicy(ctx context.Context, policy *CommercialPolicy) error
+	GetPoliciesList(ctx context.Context, policy *CommercialPolicy) ([]CommercialPolicy, error)
+}

--- a/internal/modules/policies/domain/services.go
+++ b/internal/modules/policies/domain/services.go
@@ -1,10 +1,14 @@
 package policiesdomain
 
-import "context"
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
 
 type PoliciesServicesInterface interface {
-	CreatePolicy(ctx context.Context, policy *CommercialPolicy) error
 	GetPolicyByKey(ctx context.Context, key string) (*CommercialPolicy, error)
 	UpdatePolicy(ctx context.Context, policy *CommercialPolicy) error
 	GetPoliciesList(ctx context.Context, policy *CommercialPolicy) ([]CommercialPolicy, error)
+	GetPolicyByID(ctx context.Context, policyID uuid.UUID) (*CommercialPolicy, error)
 }

--- a/internal/modules/policies/handler/payload.go
+++ b/internal/modules/policies/handler/payload.go
@@ -1,0 +1,15 @@
+package policieshandler
+
+type UpdatePolicyValue struct {
+	Value string `json:"value"`
+}
+
+type PolicyResponse struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Value       string `json:"value"`
+	Category    string `json:"category"`
+	Active      bool   `json:"active"`
+	DataType    string `json:"data_type"`
+}

--- a/internal/modules/policies/handler/policies_handler.go
+++ b/internal/modules/policies/handler/policies_handler.go
@@ -92,11 +92,11 @@ func (h *PoliciesHandler) GetPoliciesListHandler(c *gin.Context) {
 // @Tags			Policies
 // @Security		ApiKeyAuth
 // @Produce		json
-// @Param			id	path		string							true	"Policy UUID"
-// @Success		200	{object}	object{data=PolicyResponse}		"Policy details"
-// @Failure		400	{object}	map[string]interface{}			"Bad Request: Invalid UUID format"
-// @Failure		404	{object}	map[string]interface{}			"Not Found: Policy not found"
-// @Failure		500	{object}	map[string]interface{}			"Internal Server Error"
+// @Param			id	path		string						true	"Policy UUID"
+// @Success		200	{object}	object{data=PolicyResponse}	"Policy details"
+// @Failure		400	{object}	map[string]interface{}		"Bad Request: Invalid UUID format"
+// @Failure		404	{object}	map[string]interface{}		"Not Found: Policy not found"
+// @Failure		500	{object}	map[string]interface{}		"Internal Server Error"
 // @Router			/policies/{id} [get]
 func (h *PoliciesHandler) GetPolicyByIDHandler(c *gin.Context) {
 	ctx := c.Request.Context()

--- a/internal/modules/policies/handler/policies_handler.go
+++ b/internal/modules/policies/handler/policies_handler.go
@@ -1,1 +1,131 @@
 package policieshandler
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	policiesdomain "github.com/vitalfit/api/internal/modules/policies/domain"
+	shared_errors "github.com/vitalfit/api/internal/shared/errors"
+)
+
+// @Summary		Update a policy
+// @Description	Updates an existing policy's value.
+// @Tags			Policies
+// @Security		ApiKeyAuth
+// @Accept			json
+// @Produce		json
+// @Param			id		path		string					true	"Policy UUID"
+// @Param			policy	body		UpdatePolicyValue		true	"Payload with value to update"
+// @Success		204		{object}	nil						"Policy updated successfully"
+// @Failure		400		{object}	map[string]interface{}	"Bad Request: Invalid UUID or payload"
+// @Failure		404		{object}	map[string]interface{}	"Not Found: Policy not found"
+// @Failure		500		{object}	map[string]interface{}	"Internal Server Error"
+// @Router			/policies/{id} [put]
+func (h *PoliciesHandler) UpdatePolicyHandler(c *gin.Context) {
+	ctx := c.Request.Context()
+	var payload UpdatePolicyValue
+	if err := c.ShouldBindJSON(&payload); err != nil {
+		h.services.LogErrors.BadRequestResponse(c, err)
+		return
+	}
+
+	policyID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		h.services.LogErrors.BadRequestResponse(c, err)
+		return
+	}
+
+	policy := &policiesdomain.CommercialPolicy{
+		ID:    policyID,
+		Value: payload.Value,
+	}
+
+	err = h.services.Policies.UpdatePolicy(ctx, policy)
+	if err != nil {
+		switch err {
+		case shared_errors.ErrNotFound:
+			h.services.LogErrors.NotFoundResponse(c)
+		default:
+			h.services.LogErrors.InternalServerError(c, err)
+		}
+		return
+	}
+
+	c.JSON(http.StatusNoContent, nil)
+}
+
+// @Summary		List all policies
+// @Description	Retrieves a list of all commercial policies.
+// @Tags			Policies
+// @Security		ApiKeyAuth
+// @Produce		json
+// @Success		200	{object}	object{data=[]PolicyResponse}	"List of policies"
+// @Failure		500	{object}	map[string]interface{}			"Internal server error"
+// @Router			/policies [get]
+func (h *PoliciesHandler) GetPoliciesListHandler(c *gin.Context) {
+	ctx := c.Request.Context()
+	policies, err := h.services.Policies.GetPoliciesList(ctx, nil)
+	if err != nil {
+		h.services.LogErrors.InternalServerError(c, err)
+		return
+	}
+
+	response := make([]PolicyResponse, 0, len(policies))
+	for _, p := range policies {
+		response = append(response, PolicyResponse{
+			ID:          p.ID.String(),
+			Name:        p.DisplayName,
+			Description: p.Description,
+			Value:       p.Value,
+			Category:    p.PolicyKey,
+			Active:      p.IsActive,
+			DataType:    p.DataType,
+		})
+	}
+
+	c.JSON(http.StatusOK, gin.H{"data": response})
+}
+
+// @Summary		Get policy by ID
+// @Description	Retrieves detailed information about a specific policy by its UUID.
+// @Tags			Policies
+// @Security		ApiKeyAuth
+// @Produce		json
+// @Param			id	path		string							true	"Policy UUID"
+// @Success		200	{object}	object{data=PolicyResponse}		"Policy details"
+// @Failure		400	{object}	map[string]interface{}			"Bad Request: Invalid UUID format"
+// @Failure		404	{object}	map[string]interface{}			"Not Found: Policy not found"
+// @Failure		500	{object}	map[string]interface{}			"Internal Server Error"
+// @Router			/policies/{id} [get]
+func (h *PoliciesHandler) GetPolicyByIDHandler(c *gin.Context) {
+	ctx := c.Request.Context()
+	policyID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		h.services.LogErrors.BadRequestResponse(c, err)
+		return
+	}
+
+	policy, err := h.services.Policies.GetPolicyByID(ctx, policyID)
+	if err != nil {
+		switch err {
+		case shared_errors.ErrNotFound:
+			h.services.LogErrors.NotFoundResponse(c)
+		default:
+			h.services.LogErrors.InternalServerError(c, err)
+		}
+		return
+	}
+
+	response := PolicyResponse{
+		ID:          policy.ID.String(),
+		Name:        policy.DisplayName,
+		Description: policy.Description,
+		Value:       policy.Value,
+		Category:    policy.PolicyKey,
+		Active:      policy.IsActive,
+		DataType:    policy.DataType,
+	}
+
+	c.JSON(http.StatusOK, gin.H{"data": response})
+}

--- a/internal/modules/policies/handler/routes.go
+++ b/internal/modules/policies/handler/routes.go
@@ -21,5 +21,8 @@ func NewPoliciesHandler(services appservices.Services) *PoliciesHandler {
 }
 
 func (h *PoliciesHandler) PolicyRoutes(rg *gin.RouterGroup, m *auth.AuthMiddleware) {
-
+	policies := rg.Group("/policies").Use(m.AuthJwtTokenMiddleware())
+	policies.PUT("/:id", m.RBACPermission("policy"), h.UpdatePolicyHandler)
+	policies.GET("", m.RBACPermission("policy"), h.GetPoliciesListHandler)
+	policies.GET("/:id", m.RBACPermission("policy"), h.GetPolicyByIDHandler)
 }

--- a/internal/modules/policies/repository/policies_repository.go
+++ b/internal/modules/policies/repository/policies_repository.go
@@ -3,6 +3,7 @@ package policiesrepository
 import (
 	"context"
 
+	"github.com/google/uuid"
 	policiesdomain "github.com/vitalfit/api/internal/modules/policies/domain"
 	shared_errors "github.com/vitalfit/api/internal/shared/errors"
 	"github.com/vitalfit/api/pkg/db"
@@ -64,4 +65,18 @@ func (s *PoliciesStore) GetPoliciesList(ctx context.Context, policy *policiesdom
 		return nil, err
 	}
 	return policies, nil
+}
+
+func (s *PoliciesStore) GetPolicyByID(ctx context.Context, policyID uuid.UUID) (*policiesdomain.CommercialPolicy, error) {
+	var policy policiesdomain.CommercialPolicy
+	if err := s.db.WithContext(ctx).Where("id = ?", policyID).First(&policy).Error; err != nil {
+		switch err {
+		case gorm.ErrRecordNotFound:
+			return nil, shared_errors.ErrNotFound
+		default:
+			return nil, err
+		}
+	}
+	return &policy, nil
+
 }

--- a/internal/modules/policies/repository/policies_repository.go
+++ b/internal/modules/policies/repository/policies_repository.go
@@ -41,3 +41,17 @@ func (s *PoliciesStore) UpdatePolicy(ctx context.Context, policy *policiesdomain
 	}
 	return s.db.WithContext(ctx).Model(policy).Select("Value").Updates(policy).Error
 }
+
+func (s *PoliciesStore) GetPoliciesList(ctx context.Context, policy *policiesdomain.CommercialPolicy) ([]policiesdomain.CommercialPolicy, error) {
+	var policies []policiesdomain.CommercialPolicy
+	query := s.db.WithContext(ctx)
+
+	if policy != nil {
+		query = query.Where(policy)
+	}
+
+	if err := query.Find(&policies).Error; err != nil {
+		return nil, err
+	}
+	return policies, nil
+}

--- a/internal/modules/policies/repository/policies_repository.go
+++ b/internal/modules/policies/repository/policies_repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	policiesdomain "github.com/vitalfit/api/internal/modules/policies/domain"
+	"github.com/vitalfit/api/pkg/db"
 	"gorm.io/gorm"
 )
 
@@ -18,12 +19,25 @@ func NewPoliciesStore(db *gorm.DB) *PoliciesStore {
 
 }
 
-func (s *PoliciesStore) CreatePolicyTx(ctx context.Context, tx *gorm.DB, policy *policiesdomain.CommercialPolicy) error {
-
-	return nil
+func (s *PoliciesStore) CreatePolicy(ctx context.Context, policy *policiesdomain.CommercialPolicy) error {
+	return db.WithTX(s.db, func(tx *gorm.DB) error {
+		return tx.WithContext(ctx).Create(policy).Error
+	})
 }
 
-func (s *PoliciesStore) CreatePolicy(ctx context.Context, policy *policiesdomain.CommercialPolicy) error {
+func (s *PoliciesStore) GetPolicyByKey(ctx context.Context, key string) (*policiesdomain.CommercialPolicy, error) {
+	var policy policiesdomain.CommercialPolicy
+	if err := s.db.WithContext(ctx).Where("policy_key = ?", key).First(&policy).Error; err != nil {
+		return nil, err
+	}
+	return &policy, nil
+}
 
-	return nil
+func (s *PoliciesStore) UpdatePolicy(ctx context.Context, policy *policiesdomain.CommercialPolicy) error {
+	if policy.DataType != "" {
+		if _, err := policy.ParseValue(); err != nil {
+			return err
+		}
+	}
+	return s.db.WithContext(ctx).Model(policy).Select("Value").Updates(policy).Error
 }

--- a/internal/modules/policies/repository/policies_repository.go
+++ b/internal/modules/policies/repository/policies_repository.go
@@ -19,6 +19,10 @@ func NewPoliciesStore(db *gorm.DB) *PoliciesStore {
 
 }
 
+func (s *PoliciesStore) CreatePolicyTx(ctx context.Context, tx *gorm.DB, policy *policiesdomain.CommercialPolicy) error {
+	return tx.WithContext(ctx).Create(policy).Error
+}
+
 func (s *PoliciesStore) CreatePolicy(ctx context.Context, policy *policiesdomain.CommercialPolicy) error {
 	return db.WithTX(s.db, func(tx *gorm.DB) error {
 		return tx.WithContext(ctx).Create(policy).Error

--- a/internal/modules/policies/repository/policies_repository.go
+++ b/internal/modules/policies/repository/policies_repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	policiesdomain "github.com/vitalfit/api/internal/modules/policies/domain"
+	shared_errors "github.com/vitalfit/api/internal/shared/errors"
 	"github.com/vitalfit/api/pkg/db"
 	"gorm.io/gorm"
 )
@@ -32,7 +33,12 @@ func (s *PoliciesStore) CreatePolicy(ctx context.Context, policy *policiesdomain
 func (s *PoliciesStore) GetPolicyByKey(ctx context.Context, key string) (*policiesdomain.CommercialPolicy, error) {
 	var policy policiesdomain.CommercialPolicy
 	if err := s.db.WithContext(ctx).Where("policy_key = ?", key).First(&policy).Error; err != nil {
-		return nil, err
+		switch err {
+		case gorm.ErrRecordNotFound:
+			return nil, shared_errors.ErrNotFound
+		default:
+			return nil, err
+		}
 	}
 	return &policy, nil
 }

--- a/internal/modules/policies/services/policies_services.go
+++ b/internal/modules/policies/services/policies_services.go
@@ -1,6 +1,11 @@
 package policiesservices
 
-import "github.com/vitalfit/api/internal/store"
+import (
+	"context"
+
+	policiesdomain "github.com/vitalfit/api/internal/modules/policies/domain"
+	"github.com/vitalfit/api/internal/store"
+)
 
 type PoliciesServices struct {
 	store store.Storage
@@ -10,4 +15,18 @@ func NewPoliciesServices(store store.Storage) *PoliciesServices {
 	return &PoliciesServices{
 		store: store,
 	}
+}
+
+func (s *PoliciesServices) CreatePolicy(ctx context.Context, policy *policiesdomain.CommercialPolicy) error {
+	return s.store.Policies.CreatePolicy(ctx, policy)
+}
+
+func (s *PoliciesServices) GetPolicyByKey(ctx context.Context, key string) (*policiesdomain.CommercialPolicy, error) {
+	return s.store.Policies.GetPolicyByKey(ctx, key)
+}
+func (s *PoliciesServices) UpdatePolicy(ctx context.Context, policy *policiesdomain.CommercialPolicy) error {
+	return s.store.Policies.UpdatePolicy(ctx, policy)
+}
+func (s *PoliciesServices) GetPoliciesList(ctx context.Context, policy *policiesdomain.CommercialPolicy) ([]policiesdomain.CommercialPolicy, error) {
+	return s.store.Policies.GetPoliciesList(ctx, policy)
 }

--- a/internal/modules/policies/services/policies_services.go
+++ b/internal/modules/policies/services/policies_services.go
@@ -3,6 +3,7 @@ package policiesservices
 import (
 	"context"
 
+	"github.com/google/uuid"
 	policiesdomain "github.com/vitalfit/api/internal/modules/policies/domain"
 	"github.com/vitalfit/api/internal/store"
 )
@@ -29,4 +30,7 @@ func (s *PoliciesServices) UpdatePolicy(ctx context.Context, policy *policiesdom
 }
 func (s *PoliciesServices) GetPoliciesList(ctx context.Context, policy *policiesdomain.CommercialPolicy) ([]policiesdomain.CommercialPolicy, error) {
 	return s.store.Policies.GetPoliciesList(ctx, policy)
+}
+func (s *PoliciesServices) GetPolicyByID(ctx context.Context, policyID uuid.UUID) (*policiesdomain.CommercialPolicy, error) {
+	return s.store.Policies.GetPolicyByID(ctx, policyID)
 }

--- a/internal/modules/schedule/domain/repository.go
+++ b/internal/modules/schedule/domain/repository.go
@@ -25,5 +25,8 @@ type ScheduleRepository interface {
 	// DeleteClass elimina (o realiza soft-delete) una clase programada.
 	DeleteClass(ctx context.Context, classID uuid.UUID) error
 
+	// GetUpcomingClassesByBranch obtiene las clases futuras (o en curso) de una sucursal.
+	GetUpcomingClassesByBranch(ctx context.Context, branchID uuid.UUID) ([]Class, error)
+
 	GetAvailableClassesForBranch(ctx context.Context, branchID uuid.UUID, startTime, endTime time.Time) ([]Class, error)
 }

--- a/internal/modules/schedule/domain/repository.go
+++ b/internal/modules/schedule/domain/repository.go
@@ -13,6 +13,9 @@ type ScheduleRepository interface {
 	// CreateClass crea una nueva clase programada.
 	CreateClass(ctx context.Context, class *Class) error
 
+	// CreateClasses crea múltiples clases programadas (para recurrencia).
+	CreateClasses(ctx context.Context, classes []Class) error
+
 	// GetClassesByBranch obtiene todas las clases programadas de una sucursal.
 	GetClassesByBranch(ctx context.Context, branchID uuid.UUID) ([]Class, error)
 

--- a/internal/modules/schedule/domain/service.go
+++ b/internal/modules/schedule/domain/service.go
@@ -12,4 +12,5 @@ type ScheduleServiceInterface interface {
 	GetClassByID(ctx context.Context, classID uuid.UUID) (*Class, error)
 	UpdateClass(ctx context.Context, class *Class) error
 	DeleteClass(ctx context.Context, classID uuid.UUID) error
+	GetUpcomingClassesByBranch(ctx context.Context, branchID uuid.UUID) ([]Class, error)
 }

--- a/internal/modules/schedule/domain/service.go
+++ b/internal/modules/schedule/domain/service.go
@@ -8,6 +8,7 @@ import (
 
 type ScheduleServiceInterface interface {
 	CreateClass(ctx context.Context, class *Class) error
+	CreateClasses(ctx context.Context, classes []Class) error
 	GetClassesByBranch(ctx context.Context, branchID uuid.UUID) ([]Class, error)
 	GetClassByID(ctx context.Context, classID uuid.UUID) (*Class, error)
 	UpdateClass(ctx context.Context, class *Class) error

--- a/internal/modules/schedule/handlers/payload.go
+++ b/internal/modules/schedule/handlers/payload.go
@@ -12,13 +12,15 @@ import (
 // --------------------
 
 type CreateClassPayload struct {
-	ServiceID    string    `json:"service_id" binding:"required"`
-	InstructorID string    `json:"instructor_id" binding:"required"`
-	StartsAt     time.Time `json:"starts_at" binding:"required"`
-	EndsAt       time.Time `json:"ends_at" binding:"required"`
-	MaxCapacity  int       `json:"max_capacity" binding:"required,gte=1"`
-	IsVisible    bool      `json:"is_visible"`
-	Notes        string    `json:"notes"`
+	ServiceID       string    `json:"service_id" binding:"required"`
+	InstructorID    string    `json:"instructor_id" binding:"required"`
+	StartsAt        time.Time `json:"starts_at" binding:"required"`
+	EndsAt          time.Time `json:"ends_at" binding:"required"`
+	MaxCapacity     int       `json:"max_capacity" binding:"required,gte=1"`
+	IsVisible       bool      `json:"is_visible"`
+	Notes           string    `json:"notes"`
+	Recurrence      string    `json:"recurrence" binding:"omitempty,oneof=daily weekly none"`
+	RecurrenceUntil time.Time `json:"recurrence_until"`
 }
 
 func (p *CreateClassPayload) ToClass(branchID uuid.UUID) (*scheduledomain.Class, error) {

--- a/internal/modules/schedule/handlers/schedule_handlers.go
+++ b/internal/modules/schedule/handlers/schedule_handlers.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	scheduledomain "github.com/vitalfit/api/internal/modules/schedule/domain"
 	"gorm.io/gorm"
 )
 
@@ -95,7 +96,13 @@ func (h *ScheduleHandlers) GetClassesByBranchHandler(c *gin.Context) {
 		return
 	}
 
-	classes, err := h.services.ScheduleServices.GetClassesByBranch(ctx, branchID)
+	var classes []scheduledomain.Class
+	if user.Role.Name == "client" {
+		classes, err = h.services.ScheduleServices.GetUpcomingClassesByBranch(ctx, branchID)
+	} else {
+		classes, err = h.services.ScheduleServices.GetClassesByBranch(ctx, branchID)
+	}
+
 	if err != nil {
 		switch err {
 		case gorm.ErrRecordNotFound:

--- a/internal/modules/schedule/handlers/schedule_handlers.go
+++ b/internal/modules/schedule/handlers/schedule_handlers.go
@@ -2,9 +2,11 @@ package schedulehandlers
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	branchdomain "github.com/vitalfit/api/internal/modules/branches/domain"
 	scheduledomain "github.com/vitalfit/api/internal/modules/schedule/domain"
 	"gorm.io/gorm"
 )
@@ -40,13 +42,89 @@ func (h *ScheduleHandlers) CreateClassHandler(c *gin.Context) {
 		return
 	}
 
+	branch, err := h.services.BranchesServices.GetBranchByID(ctx, branchID)
+	if err != nil {
+		h.services.LogErrors.BadRequestResponse(c, err)
+		return
+	}
+
 	class, err := payload.ToClass(branchID)
 	if err != nil {
 		h.services.LogErrors.BadRequestResponse(c, err)
 		return
 	}
 
-	if err := h.services.ScheduleServices.CreateClass(ctx, class); err != nil {
+	// Logic for recurrence
+	var classes []scheduledomain.Class
+	classes = append(classes, *class)
+
+	if payload.Recurrence == "daily" || payload.Recurrence == "weekly" {
+		// Limit recurrence to max 3 months to prevent infinite or too long creation
+		maxDate := class.StartsAt.AddDate(0, 3, 0)
+		limitDate := payload.RecurrenceUntil
+		if limitDate.IsZero() || limitDate.After(maxDate) {
+			limitDate = maxDate
+		}
+
+		nextStart := class.StartsAt
+		nextEnd := class.EndsAt
+
+		// Map operational days for quick lookup
+		operationalDays := make(map[branchdomain.DayOfWeekEnum]bool)
+		for _, oh := range branch.OperatingHours {
+			if !oh.IsClosed {
+				operationalDays[oh.DayOfWeek] = true
+			}
+		}
+
+		for {
+			if payload.Recurrence == "daily" {
+				nextStart = nextStart.AddDate(0, 0, 1)
+				nextEnd = nextEnd.AddDate(0, 0, 1)
+			} else if payload.Recurrence == "weekly" {
+				nextStart = nextStart.AddDate(0, 0, 7)
+				nextEnd = nextEnd.AddDate(0, 0, 7)
+			}
+
+			if nextStart.After(limitDate) {
+				break
+			}
+
+			// Skip non-operational days if operating hours are defined
+			if len(branch.OperatingHours) > 0 {
+				var dayEnum branchdomain.DayOfWeekEnum
+				switch nextStart.Weekday() {
+				case time.Monday:
+					dayEnum = branchdomain.DayMonday
+				case time.Tuesday:
+					dayEnum = branchdomain.DayTuesday
+				case time.Wednesday:
+					dayEnum = branchdomain.DayWednesday
+				case time.Thursday:
+					dayEnum = branchdomain.DayThursday
+				case time.Friday:
+					dayEnum = branchdomain.DayFriday
+				case time.Saturday:
+					dayEnum = branchdomain.DaySaturday
+				case time.Sunday:
+					dayEnum = branchdomain.DaySunday
+				}
+				if !operationalDays[dayEnum] {
+					continue
+				}
+			}
+
+			newClass := *class
+			newClass.StartsAt = nextStart
+			newClass.EndsAt = nextEnd
+			// Reset ID to allow generation of new UUID
+			newClass.ClassID = uuid.Nil
+
+			classes = append(classes, newClass)
+		}
+	}
+
+	if err := h.services.ScheduleServices.CreateClasses(ctx, classes); err != nil {
 		h.services.LogErrors.InternalServerError(c, err)
 		return
 	}

--- a/internal/modules/schedule/repository/schedule_repository.go
+++ b/internal/modules/schedule/repository/schedule_repository.go
@@ -62,6 +62,35 @@ func (s *ScheduleStore) GetClassesByBranch(ctx context.Context, branchID uuid.UU
 }
 
 // ----------------------------------------
+// GetUpcomingClassesByBranch
+// ----------------------------------------
+
+func (s *ScheduleStore) GetUpcomingClassesByBranch(ctx context.Context, branchID uuid.UUID) ([]scheduledomain.Class, error) {
+	var classes []scheduledomain.Class
+
+	err := db.WithTX(s.db, func(tx *gorm.DB) error {
+
+		if err := tx.WithContext(ctx).
+			Preload("Service").
+			Preload("Instructor").
+			Preload("Branch").
+			Where("branch_id = ?", branchID).
+			Where("ends_at > ?", time.Now()).
+			Find(&classes).Error; err != nil {
+			return err
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return classes, nil
+}
+
+// ----------------------------------------
 // GetClassByID
 // ----------------------------------------
 

--- a/internal/modules/schedule/repository/schedule_repository.go
+++ b/internal/modules/schedule/repository/schedule_repository.go
@@ -34,6 +34,19 @@ func (s *ScheduleStore) CreateClass(ctx context.Context, class *scheduledomain.C
 }
 
 // ----------------------------------------
+// CreateClasses (Batch)
+// ----------------------------------------
+
+func (s *ScheduleStore) CreateClasses(ctx context.Context, classes []scheduledomain.Class) error {
+	return db.WithTX(s.db, func(tx *gorm.DB) error {
+		if err := tx.WithContext(ctx).Create(&classes).Error; err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+// ----------------------------------------
 // GetClassesByBranch
 // ----------------------------------------
 

--- a/internal/modules/schedule/service/schedule_service.go
+++ b/internal/modules/schedule/service/schedule_service.go
@@ -40,6 +40,10 @@ func (s *ScheduleService) GetClassesByBranch(ctx context.Context, branchID uuid.
 	return s.store.Schedule.GetClassesByBranch(ctx, branchID)
 }
 
+func (s *ScheduleService) GetUpcomingClassesByBranch(ctx context.Context, branchID uuid.UUID) ([]scheduledomain.Class, error) {
+	return s.store.Schedule.GetUpcomingClassesByBranch(ctx, branchID)
+}
+
 // ----------------------------------------
 // GetClassByID
 // ----------------------------------------

--- a/internal/modules/schedule/service/schedule_service.go
+++ b/internal/modules/schedule/service/schedule_service.go
@@ -33,6 +33,19 @@ func (s *ScheduleService) CreateClass(ctx context.Context, class *scheduledomain
 }
 
 // ----------------------------------------
+// CreateClasses
+// ----------------------------------------
+
+func (s *ScheduleService) CreateClasses(ctx context.Context, classes []scheduledomain.Class) error {
+	for _, class := range classes {
+		if !class.StartsAt.Before(class.EndsAt) {
+			return errors.New("the class start time must be before the end time")
+		}
+	}
+	return s.store.Schedule.CreateClasses(ctx, classes)
+}
+
+// ----------------------------------------
 // GetClassesByBranch
 // ----------------------------------------
 


### PR DESCRIPTION
### Description

This PR significantly upgrades the Scheduling module with two critical features:

1. Class Recurrence (New Logic):

    Implemented the logic to support Recurring Classes during creation.

    Staff can now create a class once and define a repetition pattern, reducing manual data entry for weekly schedules.

2. Client-Facing Schedule (Optimization):

    Refactored the get branch schedule endpoint.

    Added filtering logic to ensure Clients only see valid, bookable classes.

    Hidden classes, internal staff blocks, or past/invalid sessions are now correctly filtered out from the client's view.

(Note: This PR also includes recent fixes to database seeds and updates to the Policy repository interface found in the commit history).
Related Issue

N/A
### Motivation and Context

    Operational Efficiency: Without recurrence, gym managers had to manually create every single class for every week, which is prone to error and time-consuming.

    User Experience: Clients were previously seeing classes they couldn't actually book (or invalid entries), leading to confusion and failed booking attempts. This update ensures a clean UI for the end-user.

### How Has This Been Tested?

    Recurrence: Created a class with a "Weekly" repetition pattern and verified in the database that the future sessions were generated correctly.

    Client View: Logged in as a generic client and requested the branch schedule. Verified that only active, future classes were returned and that "Staff Only" classes were excluded.