### PR TITLE
feat(reports): Add Sales by Demographics & Policy Seeding

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -8859,6 +8859,77 @@ const docTemplate = `{
                 }
             }
         },
+        "/reports/charts/sales-by-demographics": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Retrieves sales volume grouped by demographic dimension (age or gender).",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Reports"
+                ],
+                "summary": "Get Sales By Demographics",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Filter by Branch UUID",
+                        "name": "branch_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Start date (YYYY-MM-DD)",
+                        "name": "start",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "End date (YYYY-MM-DD)",
+                        "name": "end",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Dimension: 'age' or 'gender'",
+                        "name": "dimension",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Demographic sales data",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/reportdomain.ChartData"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/reports/charts/sales-by-hour": {
             "get": {
                 "security": [

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -8851,6 +8851,77 @@
                 }
             }
         },
+        "/reports/charts/sales-by-demographics": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Retrieves sales volume grouped by demographic dimension (age or gender).",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Reports"
+                ],
+                "summary": "Get Sales By Demographics",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Filter by Branch UUID",
+                        "name": "branch_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Start date (YYYY-MM-DD)",
+                        "name": "start",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "End date (YYYY-MM-DD)",
+                        "name": "end",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Dimension: 'age' or 'gender'",
+                        "name": "dimension",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Demographic sales data",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/reportdomain.ChartData"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/reports/charts/sales-by-hour": {
             "get": {
                 "security": [

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -8209,6 +8209,52 @@ paths:
       summary: Get Sales Volume By Service (Category)
       tags:
       - Reports
+  /reports/charts/sales-by-demographics:
+    get:
+      description: Retrieves sales volume grouped by demographic dimension (age or
+        gender).
+      parameters:
+      - description: Filter by Branch UUID
+        in: query
+        name: branch_id
+        type: string
+      - description: Start date (YYYY-MM-DD)
+        in: query
+        name: start
+        type: string
+      - description: End date (YYYY-MM-DD)
+        in: query
+        name: end
+        type: string
+      - description: 'Dimension: ''age'' or ''gender'''
+        in: query
+        name: dimension
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Demographic sales data
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/definitions/reportdomain.ChartData'
+                type: array
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+      security:
+      - ApiKeyAuth: []
+      summary: Get Sales By Demographics
+      tags:
+      - Reports
   /reports/charts/sales-by-hour:
     get:
       description: Retrieves sales data grouped by the hour of the day for a Line

--- a/internal/migrate/seed/main.go
+++ b/internal/migrate/seed/main.go
@@ -32,6 +32,7 @@ import (
 	inventorydomain "github.com/vitalfit/api/internal/modules/inventory/domain"
 	marketingdomain "github.com/vitalfit/api/internal/modules/marketing/domain"
 	membershipsdomain "github.com/vitalfit/api/internal/modules/memberships/domain"
+	policiesdomain "github.com/vitalfit/api/internal/modules/policies/domain"
 	productsdomain "github.com/vitalfit/api/internal/modules/products/domain"
 	scheduledomain "github.com/vitalfit/api/internal/modules/schedule/domain"
 	"github.com/vitalfit/api/internal/store"
@@ -57,6 +58,7 @@ func (s *SeedStruct) Seed(store store.Storage, db *gorm.DB, services appservices
 	s.SeedPermissions(store, db, ctx)
 	s.SeedRolePermissions(store, db, ctx)
 	s.SeedUsers(store, db, ctx)
+	s.SeedPolicies(store, db, ctx)
 	s.SeedServiceCategories(store, db, ctx)
 	s.SeedBanners(store, db, ctx)
 	s.SeedServices(store, db, ctx)
@@ -1390,6 +1392,62 @@ func (s *SeedStruct) SeedStaffAssignment(store store.Storage, db *gorm.DB, ctx c
 	}
 
 	log.Printf("Staff assignment seeding completed. Successfully assigned: %d/%d users.", successCount, len(users))
+}
+
+type policyJSON struct {
+	PolicyKey   string   `json:"policy_key"`
+	DisplayName string   `json:"display_name"`
+	Description string   `json:"description"`
+	Value       string   `json:"value"`
+	DataType    string   `json:"data_type"`
+	MinLimit    *float64 `json:"min_limit"`
+	MaxLimit    *float64 `json:"max_limit"`
+	IsActive    bool     `json:"is_active"`
+}
+
+func (s *SeedStruct) SeedPolicies(store store.Storage, db *gorm.DB, ctx context.Context) {
+	jsonFile, err := os.ReadFile("./internal/migrate/seed/data/policies.json")
+	if err != nil {
+		log.Fatalf("Fatal error: could not read policies.json file: %v", err)
+		return
+	}
+
+	var policiesFromJSON []policyJSON
+	if err = json.Unmarshal(jsonFile, &policiesFromJSON); err != nil {
+		log.Fatalf("Fatal error: could not decode policies.json: %v", err)
+		return
+	}
+
+	log.Printf("Found %d policies in policies.json. Starting seeder...", len(policiesFromJSON))
+
+	err = db.Transaction(func(tx *gorm.DB) error {
+		for _, p := range policiesFromJSON {
+			policy := &policiesdomain.CommercialPolicy{
+				PolicyKey:   p.PolicyKey,
+				DisplayName: p.DisplayName,
+				Description: p.Description,
+				Value:       p.Value,
+				DataType:    p.DataType,
+				MinLimit:    p.MinLimit,
+				MaxLimit:    p.MaxLimit,
+				IsActive:    p.IsActive,
+				CreatedAt:   time.Now(),
+			}
+
+			if err := store.Policies.CreatePolicyTx(ctx, tx, policy); err != nil {
+				log.Printf("Error creating policy '%s': %v", p.PolicyKey, err)
+				return err
+			}
+		}
+		return nil
+	})
+
+	if err != nil {
+		log.Println("Error in policies seeder, transaction was rolled back:", err)
+		return
+	}
+
+	log.Println("Policies seeder completed successfully.")
 }
 
 func main() {

--- a/internal/modules/reports/domain/repository.go
+++ b/internal/modules/reports/domain/repository.go
@@ -49,4 +49,5 @@ type ReportRepository interface {
 	GetNewVsRecurringChart(ctx context.Context, branchID *uuid.UUID) ([]StackedChartData, error)
 	GetCohortAnalysis(ctx context.Context, branchID *uuid.UUID) ([]CohortRetention, error)
 	GetMonthlyCashFlowChart(ctx context.Context, branchID *uuid.UUID) ([]ChartData, error)
+	GetSalesByDemographics(ctx context.Context, branchID *uuid.UUID, start, end time.Time, dimension string) ([]ChartData, error)
 }

--- a/internal/modules/reports/domain/service.go
+++ b/internal/modules/reports/domain/service.go
@@ -49,4 +49,5 @@ type ReportServiceInterface interface {
 	GetNewVsRecurringChart(ctx context.Context, branchID *uuid.UUID) ([]StackedChartData, error)
 	GetCohortAnalysis(ctx context.Context, branchID *uuid.UUID) ([]CohortRetention, error)
 	GetMonthlyCashFlowChart(ctx context.Context, branchID *uuid.UUID) ([]ChartData, error)
+	GetSalesByDemographics(ctx context.Context, branchID *uuid.UUID, start, end time.Time, dimension string) ([]ChartData, error)
 }

--- a/internal/modules/reports/handlers/charts_handlers.go
+++ b/internal/modules/reports/handlers/charts_handlers.go
@@ -197,3 +197,34 @@ func (h *ReportHanlders) GetNewVsRecurringChartHandler(c *gin.Context) {
 	}
 	c.JSON(http.StatusOK, gin.H{"data": data})
 }
+
+// @Summary		Get Sales By Demographics
+// @Description	Retrieves sales volume grouped by demographic dimension (age or gender).
+// @Tags			Reports
+// @Security		ApiKeyAuth
+// @Produce		json
+// @Param			branch_id	query		string									false	"Filter by Branch UUID"
+// @Param			start		query		string									false	"Start date (YYYY-MM-DD)"
+// @Param			end			query		string									false	"End date (YYYY-MM-DD)"
+// @Param			dimension	query		string									true	"Dimension: 'age' or 'gender'"
+// @Success		200			{object}	object{data=[]reportdomain.ChartData}	"Demographic sales data"
+// @Failure		500			{object}	object{error=string}					"Internal Server Error"
+// @Router			/reports/charts/sales-by-demographics [get]
+func (h *ReportHanlders) GetSalesByDemographicsHandler(c *gin.Context) {
+	ctx := c.Request.Context()
+	start, end := parseTimeRange(c)
+	dimension := c.Query("dimension")
+	var branchID *uuid.UUID
+	if idStr := c.Query("branch_id"); idStr != "" {
+		if id, err := uuid.Parse(idStr); err == nil {
+			branchID = &id
+		}
+	}
+
+	data, err := h.services.ReportServices.GetSalesByDemographics(ctx, branchID, start, end, dimension)
+	if err != nil {
+		h.services.LogErrors.InternalServerError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": data})
+}

--- a/internal/modules/reports/handlers/routes.go
+++ b/internal/modules/reports/handlers/routes.go
@@ -80,6 +80,7 @@ func (r *ReportHanlders) ReportRoutes(rg *gin.RouterGroup, m *auth.AuthMiddlewar
 		salesGroup.GET("/charts/monthly-revenue", r.GetMonthlyRevenueChartHandler)
 		salesGroup.GET("/charts/new-vs-recurring", r.GetNewVsRecurringChartHandler)
 		salesGroup.GET("/charts/cohort-analysis", r.GetCohortAnalysisHandler)
+		salesGroup.GET("/charts/sales-by-demographics", r.GetSalesByDemographicsHandler)
 	}
 
 	// Financial Routes

--- a/internal/modules/reports/repository/reports_repository.go
+++ b/internal/modules/reports/repository/reports_repository.go
@@ -1281,3 +1281,47 @@ func (rs *ReportStore) GetMonthlyRevenueChart(ctx context.Context, branchID *uui
 
 	return chartData, nil
 }
+
+func (rs *ReportStore) GetSalesByDemographics(ctx context.Context, branchID *uuid.UUID, start, end time.Time, dimension string) ([]reportdomain.ChartData, error) {
+	var results []reportdomain.ChartData
+	validStatuses := []billingdomain.InvoiceStatus{
+		billingdomain.InvoiceStatusPaid,
+		billingdomain.InvoiceStatusUnpaid,
+		billingdomain.InvoiceStatusOverdue,
+	}
+
+	query := rs.db.WithContext(ctx).Table("invoices i").
+		Joins("JOIN users u ON u.user_id = i.user_id").
+		Where("i.issue_date BETWEEN ? AND ?", start, end).
+		Where("i.status IN ?", validStatuses)
+
+	if branchID != nil {
+		query = query.Where("i.branch_id = ?", *branchID)
+	}
+
+	if dimension == "gender" {
+		err := query.Select("u.gender as label, COALESCE(SUM(i.total_amount), 0) as value").
+			Group("u.gender").
+			Scan(&results).Error
+		return results, err
+	} else if dimension == "age" {
+		ageCase := `CASE
+			WHEN u.birth_date IS NULL THEN 'Unknown'
+			WHEN EXTRACT(YEAR FROM age(u.birth_date)) < 18 THEN '< 18'
+			WHEN EXTRACT(YEAR FROM age(u.birth_date)) BETWEEN 18 AND 24 THEN '18-24'
+			WHEN EXTRACT(YEAR FROM age(u.birth_date)) BETWEEN 25 AND 34 THEN '25-34'
+			WHEN EXTRACT(YEAR FROM age(u.birth_date)) BETWEEN 35 AND 44 THEN '35-44'
+			WHEN EXTRACT(YEAR FROM age(u.birth_date)) BETWEEN 45 AND 54 THEN '45-54'
+			WHEN EXTRACT(YEAR FROM age(u.birth_date)) >= 55 THEN '55+'
+			ELSE 'Unknown'
+		END`
+
+		err := query.Select(ageCase + " as label, COALESCE(SUM(i.total_amount), 0) as value").
+			Group(ageCase).
+			Order("label").
+			Scan(&results).Error
+		return results, err
+	}
+
+	return nil, fmt.Errorf("invalid dimension: %s", dimension)
+}

--- a/internal/modules/reports/services/reports_service.go
+++ b/internal/modules/reports/services/reports_service.go
@@ -187,3 +187,7 @@ func (s *ReportService) GetCohortAnalysis(ctx context.Context, branchID *uuid.UU
 func (s *ReportService) GetMonthlyCashFlowChart(ctx context.Context, branchID *uuid.UUID) ([]reportdomain.ChartData, error) {
 	return s.store.Reports.GetMonthlyCashFlowChart(ctx, branchID)
 }
+
+func (s *ReportService) GetSalesByDemographics(ctx context.Context, branchID *uuid.UUID, start, end time.Time, dimension string) ([]reportdomain.ChartData, error) {
+	return s.store.Reports.GetSalesByDemographics(ctx, branchID, start, end, dimension)
+}


### PR DESCRIPTION
### Description

This PR adds a new analytical dimension to the Reports module and updates the database seeding utilities.

1. Sales by Demographics (Reports):

    Implemented a new endpoint get sales by demographics.

    This feature aggregates sales data based on user attributes (e.g., age range, gender, location), allowing for better customer segmentation analysis.

2. Database Seeding:

    Added a seed policies function to the main seeder.

    This ensures that default legal/commercial policies are correctly populated in the database for new environment setups.

Related Issue

N/A
### Motivation and Context

    Business Intelligence: Understanding who is purchasing memberships or products is critical for marketing. The current reports only showed when or how much, but not by whom.

    Development Experience: The policies table was previously empty on fresh installs, requiring manual SQL insertion. The new seeder automates this.

### How Has This Been Tested?

    API Testing: Called the demographics endpoint and verified that the sum of sales matches the global total, but broken down by categories.

    Seeding: Ran the seed command on a fresh database and verified that the policies table was populated with the expected default records.