### PR TITLE
feat(auth): Implement Stateful Sessions & Rotational Refresh Tokens

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -54,10 +54,11 @@ type AuthConfig struct {
 	Token TokenConfig
 }
 type TokenConfig struct {
-	Secret string
-	Exp    time.Duration
-	Iss    string
-	Aud    string
+	Secret     string
+	AccessExp  time.Duration
+	RefreshExp time.Duration
+	Iss        string
+	Aud        string
 }
 
 type ClerkConfig struct {
@@ -84,10 +85,11 @@ func LoadConfig() *Config {
 		},
 		Auth: AuthConfig{
 			Token: TokenConfig{
-				Secret: env.GetString("JWT_SECRET", ""),
-				Exp:    time.Hour * 24 * 3, //3 days
-				Iss:    env.GetString("JWT_ISS", ""),
-				Aud:    env.GetString("JWT_AUD", ""),
+				Secret:     env.GetString("JWT_SECRET", ""),
+				AccessExp:  time.Minute * 15,
+				RefreshExp: time.Hour * 24 * 7, //7 days
+				Iss:        env.GetString("JWT_ISS", ""),
+				Aud:        env.GetString("JWT_AUD", ""),
 			},
 		},
 		RateLimiter: ratelimiter.Config{

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -12330,6 +12330,116 @@ const docTemplate = `{
                 }
             }
         },
+        "/user/{id}/sessions": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Retrieves active sessions for a specific user. Clients can only see their own sessions.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "User"
+                ],
+                "summary": "Get User Sessions by ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/authdomain.Session"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Revokes all sessions for a specific user. Clients can only revoke their own sessions.",
+                "tags": [
+                    "User"
+                ],
+                "summary": "Revoke All Sessions by User ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "403": {
+                        "description": "Forbidden"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            }
+        },
         "/user/{id}/staff": {
             "put": {
                 "security": [

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1206,6 +1206,64 @@ const docTemplate = `{
                 }
             }
         },
+        "/auth/refresh": {
+            "post": {
+                "description": "Rotates the refresh token and issues a new access token.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Auth"
+                ],
+                "summary": "Renew Access Token",
+                "parameters": [
+                    {
+                        "description": "Refresh Token Payload",
+                        "name": "payload",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/authhandlers.RenewTokenPayload"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "tokens",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/auth/register": {
             "post": {
                 "description": "Register a new user in the system with client role",
@@ -11839,6 +11897,104 @@ const docTemplate = `{
                 }
             }
         },
+        "/user/sessions": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Retrieves all active sessions for the authenticated user.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "User"
+                ],
+                "summary": "Get User Sessions",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/authdomain.Session"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Revokes all sessions for the authenticated user.",
+                "tags": [
+                    "User"
+                ],
+                "summary": "Revoke All Sessions",
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            }
+        },
+        "/user/sessions/{id}": {
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Revokes a specific session by ID.",
+                "tags": [
+                    "User"
+                ],
+                "summary": "Revoke Session",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Session ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            }
+        },
         "/user/users": {
             "get": {
                 "security": [
@@ -12533,6 +12689,35 @@ const docTemplate = `{
                 }
             }
         },
+        "authdomain.Session": {
+            "type": "object",
+            "properties": {
+                "client_ip": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "expires_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "is_blocked": {
+                    "type": "boolean"
+                },
+                "refresh_token": {
+                    "type": "string"
+                },
+                "user_agent": {
+                    "type": "string"
+                },
+                "user_id": {
+                    "type": "string"
+                }
+            }
+        },
         "authhandlers.BranchAdminResponse": {
             "type": "object",
             "properties": {
@@ -12773,6 +12958,17 @@ const docTemplate = `{
                     "items": {
                         "type": "string"
                     }
+                }
+            }
+        },
+        "authhandlers.RenewTokenPayload": {
+            "type": "object",
+            "required": [
+                "refresh_token"
+            ],
+            "properties": {
+                "refresh_token": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -12322,6 +12322,116 @@
                 }
             }
         },
+        "/user/{id}/sessions": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Retrieves active sessions for a specific user. Clients can only see their own sessions.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "User"
+                ],
+                "summary": "Get User Sessions by ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/authdomain.Session"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Revokes all sessions for a specific user. Clients can only revoke their own sessions.",
+                "tags": [
+                    "User"
+                ],
+                "summary": "Revoke All Sessions by User ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "403": {
+                        "description": "Forbidden"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            }
+        },
         "/user/{id}/staff": {
             "put": {
                 "security": [

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1198,6 +1198,64 @@
                 }
             }
         },
+        "/auth/refresh": {
+            "post": {
+                "description": "Rotates the refresh token and issues a new access token.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Auth"
+                ],
+                "summary": "Renew Access Token",
+                "parameters": [
+                    {
+                        "description": "Refresh Token Payload",
+                        "name": "payload",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/authhandlers.RenewTokenPayload"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "tokens",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/auth/register": {
             "post": {
                 "description": "Register a new user in the system with client role",
@@ -11831,6 +11889,104 @@
                 }
             }
         },
+        "/user/sessions": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Retrieves all active sessions for the authenticated user.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "User"
+                ],
+                "summary": "Get User Sessions",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/authdomain.Session"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Revokes all sessions for the authenticated user.",
+                "tags": [
+                    "User"
+                ],
+                "summary": "Revoke All Sessions",
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            }
+        },
+        "/user/sessions/{id}": {
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Revokes a specific session by ID.",
+                "tags": [
+                    "User"
+                ],
+                "summary": "Revoke Session",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Session ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            }
+        },
         "/user/users": {
             "get": {
                 "security": [
@@ -12525,6 +12681,35 @@
                 }
             }
         },
+        "authdomain.Session": {
+            "type": "object",
+            "properties": {
+                "client_ip": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "expires_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "is_blocked": {
+                    "type": "boolean"
+                },
+                "refresh_token": {
+                    "type": "string"
+                },
+                "user_agent": {
+                    "type": "string"
+                },
+                "user_id": {
+                    "type": "string"
+                }
+            }
+        },
         "authhandlers.BranchAdminResponse": {
             "type": "object",
             "properties": {
@@ -12765,6 +12950,17 @@
                     "items": {
                         "type": "string"
                     }
+                }
+            }
+        },
+        "authhandlers.RenewTokenPayload": {
+            "type": "object",
+            "required": [
+                "refresh_token"
+            ],
+            "properties": {
+                "refresh_token": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -10120,6 +10120,77 @@ paths:
       summary: Update a client user
       tags:
       - User
+  /user/{id}/sessions:
+    delete:
+      description: Revokes all sessions for a specific user. Clients can only revoke
+        their own sessions.
+      parameters:
+      - description: User ID
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+        "403":
+          description: Forbidden
+        "500":
+          description: Internal Server Error
+      security:
+      - ApiKeyAuth: []
+      summary: Revoke All Sessions by User ID
+      tags:
+      - User
+    get:
+      description: Retrieves active sessions for a specific user. Clients can only
+        see their own sessions.
+      parameters:
+      - description: User ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/definitions/authdomain.Session'
+                type: array
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+        "403":
+          description: Forbidden
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+      security:
+      - ApiKeyAuth: []
+      summary: Get User Sessions by ID
+      tags:
+      - User
   /user/{id}/staff:
     put:
       consumes:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -69,6 +69,25 @@ definitions:
       updated_at:
         type: string
     type: object
+  authdomain.Session:
+    properties:
+      client_ip:
+        type: string
+      created_at:
+        type: string
+      expires_at:
+        type: string
+      id:
+        type: string
+      is_blocked:
+        type: boolean
+      refresh_token:
+        type: string
+      user_agent:
+        type: string
+      user_id:
+        type: string
+    type: object
   authhandlers.BranchAdminResponse:
     properties:
       first_name:
@@ -233,6 +252,13 @@ definitions:
         type: array
     required:
     - permissions
+    type: object
+  authhandlers.RenewTokenPayload:
+    properties:
+      refresh_token:
+        type: string
+    required:
+    - refresh_token
     type: object
   authhandlers.ResendActivationCodePayload:
     properties:
@@ -3255,6 +3281,45 @@ paths:
                 type: string
             type: object
       summary: Validate Password Reset Token
+      tags:
+      - Auth
+  /auth/refresh:
+    post:
+      consumes:
+      - application/json
+      description: Rotates the refresh token and issues a new access token.
+      parameters:
+      - description: Refresh Token Payload
+        in: body
+        name: payload
+        required: true
+        schema:
+          $ref: '#/definitions/authhandlers.RenewTokenPayload'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: tokens
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      summary: Renew Access Token
       tags:
       - Auth
   /auth/register:
@@ -10309,6 +10374,66 @@ paths:
       security:
       - ApiKeyAuth: []
       summary: Generate QR JWT Token
+      tags:
+      - User
+  /user/sessions:
+    delete:
+      description: Revokes all sessions for the authenticated user.
+      responses:
+        "204":
+          description: No Content
+        "500":
+          description: Internal Server Error
+      security:
+      - ApiKeyAuth: []
+      summary: Revoke All Sessions
+      tags:
+      - User
+    get:
+      description: Retrieves all active sessions for the authenticated user.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/definitions/authdomain.Session'
+                type: array
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+      security:
+      - ApiKeyAuth: []
+      summary: Get User Sessions
+      tags:
+      - User
+  /user/sessions/{id}:
+    delete:
+      description: Revokes a specific session by ID.
+      parameters:
+      - description: Session ID
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+        "500":
+          description: Internal Server Error
+      security:
+      - ApiKeyAuth: []
+      summary: Revoke Session
       tags:
       - User
   /user/users:

--- a/internal/migrate/migrations/000040_create_sessions.down.sql
+++ b/internal/migrate/migrations/000040_create_sessions.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_sessions_refresh_token;
+DROP INDEX IF EXISTS idx_sessions_user_id;
+DROP TABLE IF EXISTS sessions;

--- a/internal/migrate/migrations/000040_create_sessions.up.sql
+++ b/internal/migrate/migrations/000040_create_sessions.up.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS sessions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    
+    user_id UUID NOT NULL,
+    refresh_token TEXT,
+    user_agent TEXT,
+    client_ip VARCHAR(45),
+    
+    is_blocked BOOLEAN DEFAULT FALSE,
+    
+    expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    
+    CONSTRAINT fk_sessions_user
+        FOREIGN KEY(user_id) 
+        REFERENCES users(user_id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX idx_sessions_user_id ON sessions(user_id);
+CREATE INDEX idx_sessions_refresh_token ON sessions(refresh_token);

--- a/internal/modules/auth/domain/repository.go
+++ b/internal/modules/auth/domain/repository.go
@@ -55,6 +55,7 @@ type RolesRepository interface {
 type SessionRepository interface {
 	Create(ctx context.Context, session *Session) error
 	GetByRefreshToken(ctx context.Context, refreshToken string) (*Session, error)
+	GetByID(ctx context.Context, sessionID uuid.UUID) (*Session, error)
 	GetUserSessions(ctx context.Context, userID uuid.UUID) ([]*Session, error)
 	RotateSession(ctx context.Context, sessionID uuid.UUID, oldToken, newToken string, newExpiry time.Time) error
 	Revoke(ctx context.Context, sessionID uuid.UUID) error

--- a/internal/modules/auth/domain/repository.go
+++ b/internal/modules/auth/domain/repository.go
@@ -56,7 +56,7 @@ type SessionRepository interface {
 	Create(ctx context.Context, session *Session) error
 	GetByRefreshToken(ctx context.Context, refreshToken string) (*Session, error)
 	GetUserSessions(ctx context.Context, userID uuid.UUID) ([]*Session, error)
-	RotateSession(ctx context.Context, sessionID uuid.UUID, oldToken, newToken string) error
+	RotateSession(ctx context.Context, sessionID uuid.UUID, oldToken, newToken string, newExpiry time.Time) error
 	Revoke(ctx context.Context, sessionID uuid.UUID) error
 	RevokeAllForUser(ctx context.Context, userID uuid.UUID) error
 }

--- a/internal/modules/auth/domain/repository.go
+++ b/internal/modules/auth/domain/repository.go
@@ -55,6 +55,8 @@ type RolesRepository interface {
 type SessionRepository interface {
 	Create(ctx context.Context, session *Session) error
 	GetByRefreshToken(refreshToken string) (*Session, error)
+	GetUserSessions(userID uuid.UUID) ([]*Session, error)
+
 	Revoke(sessionID uuid.UUID) error
 	RevokeAllForUser(userID uuid.UUID) error
 }

--- a/internal/modules/auth/domain/repository.go
+++ b/internal/modules/auth/domain/repository.go
@@ -51,3 +51,10 @@ type RolesRepository interface {
 	CreatePermission(ctx context.Context, tx *gorm.DB, permission *Permission) error
 	GetPermissionByName(ctx context.Context, name string) (*Permission, error)
 }
+
+type SessionRepository interface {
+	Create(ctx context.Context, session *Session) error
+	GetByRefreshToken(refreshToken string) (*Session, error)
+	Revoke(sessionID uuid.UUID) error
+	RevokeAllForUser(userID uuid.UUID) error
+}

--- a/internal/modules/auth/domain/repository.go
+++ b/internal/modules/auth/domain/repository.go
@@ -54,9 +54,9 @@ type RolesRepository interface {
 
 type SessionRepository interface {
 	Create(ctx context.Context, session *Session) error
-	GetByRefreshToken(refreshToken string) (*Session, error)
-	GetUserSessions(userID uuid.UUID) ([]*Session, error)
-
-	Revoke(sessionID uuid.UUID) error
-	RevokeAllForUser(userID uuid.UUID) error
+	GetByRefreshToken(ctx context.Context, refreshToken string) (*Session, error)
+	GetUserSessions(ctx context.Context, userID uuid.UUID) ([]*Session, error)
+	RotateSession(ctx context.Context, sessionID uuid.UUID, oldToken, newToken string) error
+	Revoke(ctx context.Context, sessionID uuid.UUID) error
+	RevokeAllForUser(ctx context.Context, userID uuid.UUID) error
 }

--- a/internal/modules/auth/domain/service.go
+++ b/internal/modules/auth/domain/service.go
@@ -22,7 +22,7 @@ type AuthServicesInterface interface {
 	MailSenderStaff(ctx context.Context, user *Users, token string, template string) (int, error)
 	Activate(ctx context.Context, code string) error
 	ActivateStaff(ctx context.Context, token string, password string) error
-	GenerateToken(user *Users) (string, error)
+	GenerateToken(ctx context.Context, user *Users, userAgent string, clientIP string) (string, string, error)
 	ValidateToken(token string) (*jwt.Token, error)
 	CreatePasswordResetToken(ctx context.Context, email string, key string) error
 	DeleteResetToken(context.Context, uuid.UUID) error

--- a/internal/modules/auth/domain/service.go
+++ b/internal/modules/auth/domain/service.go
@@ -33,6 +33,7 @@ type AuthServicesInterface interface {
 	UpdateActivationCode(ctx context.Context, userID uuid.UUID, code string) error
 	//session
 	GetByRefreshToken(ctx context.Context, refreshToken string) (*Session, error)
+	GetSessionByID(ctx context.Context, sessionID uuid.UUID) (*Session, error)
 	GetUserSessions(ctx context.Context, userID uuid.UUID) ([]*Session, error)
 	RenewAccessToken(ctx context.Context, oldRefreshToken string) (string, string, error)
 	Revoke(ctx context.Context, sessionID uuid.UUID) error

--- a/internal/modules/auth/domain/service.go
+++ b/internal/modules/auth/domain/service.go
@@ -31,6 +31,12 @@ type AuthServicesInterface interface {
 	GenerateQrJwtToken(ctx context.Context, user *Users) (string, error)
 	UpgradePassword(ctx context.Context, user *Users) error
 	UpdateActivationCode(ctx context.Context, userID uuid.UUID, code string) error
+	//session
+	GetByRefreshToken(ctx context.Context, refreshToken string) (*Session, error)
+	GetUserSessions(ctx context.Context, userID uuid.UUID) ([]*Session, error)
+	RenewAccessToken(ctx context.Context, oldRefreshToken string) (string, string, error)
+	Revoke(ctx context.Context, sessionID uuid.UUID) error
+	RevokeAllForUser(ctx context.Context, userID uuid.UUID) error
 }
 
 type UserServicesInterface interface {

--- a/internal/modules/auth/domain/session.go
+++ b/internal/modules/auth/domain/session.go
@@ -1,0 +1,27 @@
+package authdomain
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type Session struct {
+	ID uuid.UUID `gorm:"type:uuid;default:gen_random_uuid();primaryKey" json:"id"`
+
+	UserID uuid.UUID `gorm:"type:uuid;not null;index" json:"user_id"`
+
+	RefreshToken string `gorm:"type:text;index" json:"refresh_token"`
+	UserAgent    string `gorm:"type:text" json:"user_agent"`
+	ClientIP     string `gorm:"size:45" json:"client_ip"`
+	IsBlocked    bool   `gorm:"default:false" json:"is_blocked"`
+
+	ExpiresAt time.Time `gorm:"not null" json:"expires_at"`
+	CreatedAt time.Time `gorm:"default:CURRENT_TIMESTAMP" json:"created_at"`
+
+	// User User `gorm:"foreignKey:UserID;references:UserID" json:"user,omitempty"`
+}
+
+func (Session) TableName() string {
+	return "sessions"
+}

--- a/internal/modules/auth/handlers/handlers_test.go
+++ b/internal/modules/auth/handlers/handlers_test.go
@@ -2,6 +2,7 @@ package authhandlers_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -56,7 +57,7 @@ func TestWhoAmI(t *testing.T) {
 		LastName:  "User",
 	}
 
-	testToken, err := testApp.Services.AuthServices.GenerateToken(mockUser)
+	testToken, _, err := testApp.Services.AuthServices.GenerateToken(context.Background(), mockUser, "test-agent", "127.0.0.1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -320,14 +321,14 @@ func TestRegisterUserStaffHandler(t *testing.T) {
 		Email:  "admin@example.com",
 		Role:   authdomain.Roles{RoleID: uuid.New(), Name: "super_admin"},
 	}
-	adminToken, _ := testApp.Services.AuthServices.GenerateToken(adminUser)
+	adminToken, _, _ := testApp.Services.AuthServices.GenerateToken(context.Background(), adminUser, "test-agent", "127.0.0.1")
 
 	authorizedUser := &authdomain.Users{
 		UserID: uuid.New(),
 		Email:  "authorized@example.com",
 		Role:   authdomain.Roles{RoleID: uuid.New(), Name: "branch_admin"},
 	}
-	authorizedToken, _ := testApp.Services.AuthServices.GenerateToken(authorizedUser)
+	authorizedToken, _, _ := testApp.Services.AuthServices.GenerateToken(context.Background(), authorizedUser, "test-agent", "127.0.0.1")
 
 	// User without specific permission
 	unauthorizedUser := &authdomain.Users{
@@ -335,7 +336,7 @@ func TestRegisterUserStaffHandler(t *testing.T) {
 		Email:  "unauthorized@example.com",
 		Role:   authdomain.Roles{RoleID: uuid.New(), Name: "instructor"},
 	}
-	unauthorizedToken, _ := testApp.Services.AuthServices.GenerateToken(unauthorizedUser)
+	unauthorizedToken, _, _ := testApp.Services.AuthServices.GenerateToken(context.Background(), unauthorizedUser, "test-agent", "127.0.0.1")
 
 	t.Run("should fail when unauthenticated", func(t *testing.T) {
 		req, _ := http.NewRequest(http.MethodPost, "/v1/auth/register-staff", nil)
@@ -468,7 +469,7 @@ func TestAdminRoleRoutes(t *testing.T) {
 		Email:  "roleadmin@example.com",
 		Role:   authdomain.Roles{RoleID: uuid.New(), Name: "role_administrator"},
 	}
-	adminToken, _ := testApp.Services.AuthServices.GenerateToken(adminUser)
+	adminToken, _, _ := testApp.Services.AuthServices.GenerateToken(context.Background(), adminUser, "test-agent", "127.0.0.1")
 
 	// User without permissions
 	basicUser := &authdomain.Users{
@@ -476,7 +477,7 @@ func TestAdminRoleRoutes(t *testing.T) {
 		Email:  "basic@example.com",
 		Role:   authdomain.Roles{RoleID: uuid.New(), Name: "client"},
 	}
-	basicToken, _ := testApp.Services.AuthServices.GenerateToken(basicUser)
+	basicToken, _, _ := testApp.Services.AuthServices.GenerateToken(context.Background(), basicUser, "test-agent", "127.0.0.1")
 
 	// Common setup for middleware checks
 	setupAdminMiddleware := func() {
@@ -643,7 +644,7 @@ func TestUserListHandlers(t *testing.T) {
 		Email:  "listadmin@example.com",
 		Role:   authdomain.Roles{RoleID: uuid.New(), Name: "admin"},
 	}
-	adminToken, _ := testApp.Services.AuthServices.GenerateToken(adminUser)
+	adminToken, _, _ := testApp.Services.AuthServices.GenerateToken(context.Background(), adminUser, "test-agent", "127.0.0.1")
 
 	setupMiddleware := func() {
 		userStoreMock.On("GetByID", mock.Anything, adminUser.UserID).Return(adminUser, nil).Once()
@@ -709,7 +710,7 @@ func TestUserDetailAndUpdateHandlers(t *testing.T) {
 		RoleID: adminRoleID,
 		Role:   authdomain.Roles{RoleID: adminRoleID, Name: "admin"},
 	}
-	adminToken, _ := testApp.Services.AuthServices.GenerateToken(adminUser)
+	adminToken, _, _ := testApp.Services.AuthServices.GenerateToken(context.Background(), adminUser, "test-agent", "127.0.0.1")
 
 	targetUserID := uuid.New()
 	mockUser := &authdomain.Users{UserID: targetUserID, FirstName: "Target", LastName: "User", Email: "target@example.com"}

--- a/internal/modules/auth/handlers/handlers_test.go
+++ b/internal/modules/auth/handlers/handlers_test.go
@@ -57,6 +57,9 @@ func TestWhoAmI(t *testing.T) {
 		LastName:  "User",
 	}
 
+	sessionStoreMock := testApp.Store.Session.(*authmocks.SessionStoreMock)
+	sessionStoreMock.On("Create", mock.Anything, mock.Anything).Return(nil)
+
 	testToken, _, err := testApp.Services.AuthServices.GenerateToken(context.Background(), mockUser, "test-agent", "127.0.0.1")
 	if err != nil {
 		t.Fatal(err)
@@ -109,6 +112,9 @@ func TestLoginHandler(t *testing.T) {
 	testPassword := "password123"
 	mockUser := newTestUser("login@example.com", testPassword)
 	mockUser.IsValidated = true
+
+	sessionStoreMock := testApp.Store.Session.(*authmocks.SessionStoreMock)
+	sessionStoreMock.On("Create", mock.Anything, mock.Anything).Return(nil)
 
 	t.Run("should fail with invalid credentials (wrong password)", func(t *testing.T) {
 		userStoreMock.On("GetByEmail", mock.Anything, mockUser.Email).Return(mockUser, nil).Once()
@@ -316,6 +322,9 @@ func TestRegisterUserStaffHandler(t *testing.T) {
 	roleStoreMock := testApp.Store.Roles.(*authmocks.RoleStoreMock)
 	mailerMock := testApp.Services.AuthServices.(*authservices.AuthService).Mailer.(*mailermocks.MockMailer)
 
+	sessionStoreMock := testApp.Store.Session.(*authmocks.SessionStoreMock)
+	sessionStoreMock.On("Create", mock.Anything, mock.Anything).Return(nil)
+
 	adminUser := &authdomain.Users{
 		UserID: uuid.New(),
 		Email:  "admin@example.com",
@@ -462,6 +471,9 @@ func TestAdminRoleRoutes(t *testing.T) {
 
 	userStoreMock := testApp.Store.Users.(*authmocks.UserStoreMock)
 	roleStoreMock := testApp.Store.Roles.(*authmocks.RoleStoreMock)
+
+	sessionStoreMock := testApp.Store.Session.(*authmocks.SessionStoreMock)
+	sessionStoreMock.On("Create", mock.Anything, mock.Anything).Return(nil)
 
 	// User with all role-management permissions
 	adminUser := &authdomain.Users{
@@ -639,6 +651,9 @@ func TestUserListHandlers(t *testing.T) {
 	userStoreMock := testApp.Store.Users.(*authmocks.UserStoreMock)
 	roleStoreMock := testApp.Store.Roles.(*authmocks.RoleStoreMock)
 
+	sessionStoreMock := testApp.Store.Session.(*authmocks.SessionStoreMock)
+	sessionStoreMock.On("Create", mock.Anything, mock.Anything).Return(nil)
+
 	adminUser := &authdomain.Users{
 		UserID: uuid.New(),
 		Email:  "listadmin@example.com",
@@ -702,6 +717,9 @@ func TestUserDetailAndUpdateHandlers(t *testing.T) {
 
 	userStoreMock := testApp.Store.Users.(*authmocks.UserStoreMock)
 	roleStoreMock := testApp.Store.Roles.(*authmocks.RoleStoreMock)
+
+	sessionStoreMock := testApp.Store.Session.(*authmocks.SessionStoreMock)
+	sessionStoreMock.On("Create", mock.Anything, mock.Anything).Return(nil)
 
 	adminRoleID := uuid.New()
 	adminUser := &authdomain.Users{

--- a/internal/modules/auth/handlers/payloads.go
+++ b/internal/modules/auth/handlers/payloads.go
@@ -255,3 +255,7 @@ type GetUserResponse struct {
 type OAuthLoginPayload struct {
 	SessionToken string `json:"session_token" binding:"required"`
 }
+
+type RenewTokenPayload struct {
+	RefreshToken string `json:"refresh_token" binding:"required"`
+}

--- a/internal/modules/auth/handlers/routes.go
+++ b/internal/modules/auth/handlers/routes.go
@@ -41,6 +41,11 @@ type AuthHandlersInterface interface {
 	GetPermissionsHandler(c *gin.Context)
 	AssignRolePermissionHandler(c *gin.Context)
 	DeleteRolePermissionHandler(c *gin.Context)
+	//Sessions
+	RenewAccessTokenHandler(c *gin.Context)
+	GetUserSessionsHandler(c *gin.Context)
+	RevokeSessionHandler(c *gin.Context)
+	RevokeAllSessionsHandler(c *gin.Context)
 }
 
 type AuthHandlers struct {
@@ -65,6 +70,7 @@ func (r *AuthHandlers) AuthRoutes(rg *gin.RouterGroup, m *auth.AuthMiddleware) {
 		authGroup.PUT("/activate/:token", r.ActivateStaffHanlder)
 		authGroup.POST("/login", r.LoginHandler)
 		authGroup.POST("/oauth-login", r.OAuthLoginHandler)
+		authGroup.POST("/refresh", r.RenewAccessTokenHandler)
 
 		passwordGroup := authGroup.Group("/password")
 		{
@@ -92,6 +98,10 @@ func (r *AuthHandlers) UserRoutes(rg *gin.RouterGroup, m *auth.AuthMiddleware) {
 		userGroup.GET("/whoami", r.WhoAmI)
 		userGroup.GET("/qr-token", r.GenerateQrJwtTokenHandler)
 		userGroup.POST("/change-password", r.ChangePasswordHandler)
+
+		userGroup.GET("/sessions", r.GetUserSessionsHandler)
+		userGroup.DELETE("/sessions/:id", r.RevokeSessionHandler)
+		userGroup.DELETE("/sessions", r.RevokeAllSessionsHandler)
 
 		userGroup.GET("/branch-admins",
 			m.RBACPermission("users:list"),

--- a/internal/modules/auth/handlers/routes.go
+++ b/internal/modules/auth/handlers/routes.go
@@ -44,8 +44,10 @@ type AuthHandlersInterface interface {
 	//Sessions
 	RenewAccessTokenHandler(c *gin.Context)
 	GetUserSessionsHandler(c *gin.Context)
+	GetUserSessionsByIDHandler(c *gin.Context)
 	RevokeSessionHandler(c *gin.Context)
 	RevokeAllSessionsHandler(c *gin.Context)
+	RevokeAllSessionsByIDHandler(c *gin.Context)
 }
 
 type AuthHandlers struct {
@@ -100,8 +102,10 @@ func (r *AuthHandlers) UserRoutes(rg *gin.RouterGroup, m *auth.AuthMiddleware) {
 		userGroup.POST("/change-password", r.ChangePasswordHandler)
 
 		userGroup.GET("/sessions", r.GetUserSessionsHandler)
+		userGroup.GET("/:id/sessions", r.GetUserSessionsByIDHandler)
 		userGroup.DELETE("/sessions/:id", r.RevokeSessionHandler)
 		userGroup.DELETE("/sessions", r.RevokeAllSessionsHandler)
+		userGroup.DELETE("/:id/sessions", r.RevokeAllSessionsByIDHandler)
 
 		userGroup.GET("/branch-admins",
 			m.RBACPermission("users:list"),

--- a/internal/modules/auth/handlers/user_auth_handlers.go
+++ b/internal/modules/auth/handlers/user_auth_handlers.go
@@ -316,14 +316,17 @@ func (h *AuthHandlers) LoginHandler(c *gin.Context) {
 		return
 	}
 
-	token, err := h.services.AuthServices.GenerateToken(user)
+	userAgent := c.Request.UserAgent()
+	clientIP := c.ClientIP()
+	token, refreshToken, err := h.services.AuthServices.GenerateToken(ctx, user, userAgent, clientIP)
 	if err != nil {
 		h.services.LogErrors.InternalServerError(c, err)
 		return
 	}
 
 	c.JSON(http.StatusOK, gin.H{
-		"token": token,
+		"token":         token,
+		"refresh_token": refreshToken,
 	})
 
 }
@@ -404,14 +407,17 @@ func (h *AuthHandlers) OAuthLoginHandler(c *gin.Context) {
 		return
 	}
 
-	internalToken, err := h.services.AuthServices.GenerateToken(user)
+	userAgent := c.Request.UserAgent()
+	clientIP := c.ClientIP()
+	internalToken, refreshToken, err := h.services.AuthServices.GenerateToken(ctx, user, userAgent, clientIP)
 	if err != nil {
 		h.services.LogErrors.InternalServerError(c, err)
 		return
 	}
 
 	c.JSON(http.StatusOK, gin.H{
-		"token": internalToken,
+		"token":         internalToken,
+		"refresh_token": refreshToken,
 	})
 }
 

--- a/internal/modules/auth/handlers/user_auth_handlers.go
+++ b/internal/modules/auth/handlers/user_auth_handlers.go
@@ -321,6 +321,56 @@ func (h *AuthHandlers) GetUserSessionsHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"data": sessions})
 }
 
+// @Summary		Get User Sessions by ID
+// @Description	Retrieves active sessions for a specific user. Clients can only see their own sessions.
+// @Tags			User
+// @Security		ApiKeyAuth
+// @Produce		json
+// @Param			id	path		string	true	"User ID"
+// @Success		200	{object}	object{data=[]authdomain.Session}
+// @Failure		400	{object}	object{error=string}	"Bad Request"
+// @Failure		403	{object}	object{error=string}	"Forbidden"
+// @Failure		500	{object}	object{error=string}	"Internal Server Error"
+// @Router			/user/{id}/sessions [get]
+func (h *AuthHandlers) GetUserSessionsByIDHandler(c *gin.Context) {
+	user := h.services.UserServices.GetUserFromContext(c)
+	ctx := c.Request.Context()
+
+	var targetUserID uuid.UUID
+	var err error
+
+	if user.Role.Name == "client" {
+		targetUserID = user.UserID
+	} else {
+		targetUserID, err = uuid.Parse(c.Param("id"))
+		if err != nil {
+			h.services.LogErrors.BadRequestResponse(c, err)
+			return
+		}
+
+		if user.Role.Name != "super_admin" {
+			if user.UserID != targetUserID {
+				ok, err := h.services.UserServices.RoleHasPermission(ctx, user.RoleID, "users:get")
+				if err != nil {
+					h.services.LogErrors.InternalServerError(c, err)
+					return
+				}
+				if !ok {
+					h.services.LogErrors.ForbiddenResponse(c)
+					return
+				}
+			}
+		}
+	}
+
+	sessions, err := h.services.AuthServices.GetUserSessions(ctx, targetUserID)
+	if err != nil {
+		h.services.LogErrors.InternalServerError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": sessions})
+}
+
 // @Summary		Revoke Session
 // @Description	Revokes a specific session by ID.
 // @Tags			User
@@ -337,7 +387,35 @@ func (h *AuthHandlers) RevokeSessionHandler(c *gin.Context) {
 		return
 	}
 	ctx := c.Request.Context()
-	// Nota: Idealmente se debería verificar que la sesión pertenezca al usuario antes de revocarla
+
+	// 1. Obtener la sesión para verificar el dueño
+	session, err := h.services.AuthServices.GetSessionByID(ctx, sessionID)
+	if err != nil {
+		switch err {
+		case shared_errors.ErrNotFound:
+			h.services.LogErrors.NotFoundResponse(c)
+		default:
+			h.services.LogErrors.InternalServerError(c, err)
+		}
+		return
+	}
+
+	// 2. Verificar permisos
+	user := h.services.UserServices.GetUserFromContext(c)
+	if user.Role.Name != "super_admin" {
+		if session.UserID != user.UserID {
+			ok, err := h.services.UserServices.RoleHasPermission(ctx, user.RoleID, "users:update")
+			if err != nil {
+				h.services.LogErrors.InternalServerError(c, err)
+				return
+			}
+			if !ok {
+				h.services.LogErrors.ForbiddenResponse(c)
+				return
+			}
+		}
+	}
+
 	if err := h.services.AuthServices.Revoke(ctx, sessionID); err != nil {
 		h.services.LogErrors.InternalServerError(c, err)
 		return
@@ -356,6 +434,54 @@ func (h *AuthHandlers) RevokeAllSessionsHandler(c *gin.Context) {
 	user := h.services.UserServices.GetUserFromContext(c)
 	ctx := c.Request.Context()
 	if err := h.services.AuthServices.RevokeAllForUser(ctx, user.UserID); err != nil {
+		h.services.LogErrors.InternalServerError(c, err)
+		return
+	}
+	c.JSON(http.StatusNoContent, nil)
+}
+
+// @Summary		Revoke All Sessions by User ID
+// @Description	Revokes all sessions for a specific user. Clients can only revoke their own sessions.
+// @Tags			User
+// @Security		ApiKeyAuth
+// @Param			id	path	string	true	"User ID"
+// @Success		204	"No Content"
+// @Failure		400	"Bad Request"
+// @Failure		403	"Forbidden"
+// @Failure		500	"Internal Server Error"
+// @Router			/user/{id}/sessions [delete]
+func (h *AuthHandlers) RevokeAllSessionsByIDHandler(c *gin.Context) {
+	user := h.services.UserServices.GetUserFromContext(c)
+	ctx := c.Request.Context()
+
+	var targetUserID uuid.UUID
+	var err error
+
+	if user.Role.Name == "client" {
+		targetUserID = user.UserID
+	} else {
+		targetUserID, err = uuid.Parse(c.Param("id"))
+		if err != nil {
+			h.services.LogErrors.BadRequestResponse(c, err)
+			return
+		}
+
+		if user.Role.Name != "super_admin" {
+			if user.UserID != targetUserID {
+				ok, err := h.services.UserServices.RoleHasPermission(ctx, user.RoleID, "users:update")
+				if err != nil {
+					h.services.LogErrors.InternalServerError(c, err)
+					return
+				}
+				if !ok {
+					h.services.LogErrors.ForbiddenResponse(c)
+					return
+				}
+			}
+		}
+	}
+
+	if err := h.services.AuthServices.RevokeAllForUser(ctx, targetUserID); err != nil {
 		h.services.LogErrors.InternalServerError(c, err)
 		return
 	}

--- a/internal/modules/auth/handlers/user_auth_handlers.go
+++ b/internal/modules/auth/handlers/user_auth_handlers.go
@@ -268,6 +268,100 @@ func (h *AuthHandlers) ActivateStaffHanlder(c *gin.Context) {
 
 }
 
+// @Summary		Renew Access Token
+// @Description	Rotates the refresh token and issues a new access token.
+// @Tags			Auth
+// @Accept			json
+// @Produce		json
+// @Param			payload	body		RenewTokenPayload		true	"Refresh Token Payload"
+// @Success		200		{object}	map[string]string		"tokens"
+// @Failure		400		{object}	map[string]interface{}	"Bad Request"
+// @Failure		401		{object}	map[string]interface{}	"Unauthorized"
+// @Failure		500		{object}	map[string]interface{}	"Internal Server Error"
+// @Router			/auth/refresh [post]
+func (h *AuthHandlers) RenewAccessTokenHandler(c *gin.Context) {
+	var payload RenewTokenPayload
+	if err := c.ShouldBindJSON(&payload); err != nil {
+		h.services.LogErrors.BadRequestResponse(c, err)
+		return
+	}
+	ctx := c.Request.Context()
+	accessToken, refreshToken, err := h.services.AuthServices.RenewAccessToken(ctx, payload.RefreshToken)
+	if err != nil {
+		switch err {
+		case shared_errors.ErrInvalidSession, shared_errors.ErrTokenReuse:
+			h.services.LogErrors.UnauthorizedErrorResponse(c, err)
+		default:
+			h.services.LogErrors.InternalServerError(c, err)
+		}
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"token":         accessToken,
+		"refresh_token": refreshToken,
+	})
+}
+
+// @Summary		Get User Sessions
+// @Description	Retrieves all active sessions for the authenticated user.
+// @Tags			User
+// @Security		ApiKeyAuth
+// @Produce		json
+// @Success		200	{object}	object{data=[]authdomain.Session}
+// @Failure		500	{object}	object{error=string}
+// @Router			/user/sessions [get]
+func (h *AuthHandlers) GetUserSessionsHandler(c *gin.Context) {
+	user := h.services.UserServices.GetUserFromContext(c)
+	ctx := c.Request.Context()
+	sessions, err := h.services.AuthServices.GetUserSessions(ctx, user.UserID)
+	if err != nil {
+		h.services.LogErrors.InternalServerError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": sessions})
+}
+
+// @Summary		Revoke Session
+// @Description	Revokes a specific session by ID.
+// @Tags			User
+// @Security		ApiKeyAuth
+// @Param			id	path	string	true	"Session ID"
+// @Success		204	"No Content"
+// @Failure		400	"Bad Request"
+// @Failure		500	"Internal Server Error"
+// @Router			/user/sessions/{id} [delete]
+func (h *AuthHandlers) RevokeSessionHandler(c *gin.Context) {
+	sessionID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		h.services.LogErrors.BadRequestResponse(c, err)
+		return
+	}
+	ctx := c.Request.Context()
+	// Nota: Idealmente se debería verificar que la sesión pertenezca al usuario antes de revocarla
+	if err := h.services.AuthServices.Revoke(ctx, sessionID); err != nil {
+		h.services.LogErrors.InternalServerError(c, err)
+		return
+	}
+	c.JSON(http.StatusNoContent, nil)
+}
+
+// @Summary		Revoke All Sessions
+// @Description	Revokes all sessions for the authenticated user.
+// @Tags			User
+// @Security		ApiKeyAuth
+// @Success		204	"No Content"
+// @Failure		500	"Internal Server Error"
+// @Router			/user/sessions [delete]
+func (h *AuthHandlers) RevokeAllSessionsHandler(c *gin.Context) {
+	user := h.services.UserServices.GetUserFromContext(c)
+	ctx := c.Request.Context()
+	if err := h.services.AuthServices.RevokeAllForUser(ctx, user.UserID); err != nil {
+		h.services.LogErrors.InternalServerError(c, err)
+		return
+	}
+	c.JSON(http.StatusNoContent, nil)
+}
+
 // @Summary		Logs in a user and issues a JWT token
 // @Description	Authenticates the user with email and password, returning an access token upon success.
 // @Tags			Auth

--- a/internal/modules/auth/mocks/repository_mocks.go
+++ b/internal/modules/auth/mocks/repository_mocks.go
@@ -19,6 +19,14 @@ type RoleStoreMock struct {
 	mock.Mock
 }
 
+type SessionStoreMock struct {
+	mock.Mock
+}
+
+func NewMockSessionStore() *SessionStoreMock {
+	return &SessionStoreMock{}
+}
+
 func NewMockUserStore() *UserStoreMock {
 	return &UserStoreMock{}
 }
@@ -235,4 +243,50 @@ func (m *RoleStoreMock) GetPermissionByName(ctx context.Context, name string) (*
 		return nil, args.Error(1)
 	}
 	return args.Get(0).(*authdomain.Permission), args.Error(1)
+}
+
+//session mocks
+
+func (m *SessionStoreMock) Create(ctx context.Context, session *authdomain.Session) error {
+	args := m.Called(ctx, session)
+	return args.Error(0)
+}
+
+func (m *SessionStoreMock) GetByRefreshToken(ctx context.Context, refreshToken string) (*authdomain.Session, error) {
+	args := m.Called(ctx, refreshToken)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*authdomain.Session), args.Error(1)
+}
+
+func (m *SessionStoreMock) GetByID(ctx context.Context, sessionID uuid.UUID) (*authdomain.Session, error) {
+	args := m.Called(ctx, sessionID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*authdomain.Session), args.Error(1)
+}
+
+func (m *SessionStoreMock) GetUserSessions(ctx context.Context, userID uuid.UUID) ([]*authdomain.Session, error) {
+	args := m.Called(ctx, userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*authdomain.Session), args.Error(1)
+}
+
+func (m *SessionStoreMock) RotateSession(ctx context.Context, sessionID uuid.UUID, oldToken, newToken string, newExpiry time.Time) error {
+	args := m.Called(ctx, sessionID, oldToken, newToken, newExpiry)
+	return args.Error(0)
+}
+
+func (m *SessionStoreMock) Revoke(ctx context.Context, sessionID uuid.UUID) error {
+	args := m.Called(ctx, sessionID)
+	return args.Error(0)
+}
+
+func (m *SessionStoreMock) RevokeAllForUser(ctx context.Context, userID uuid.UUID) error {
+	args := m.Called(ctx, userID)
+	return args.Error(0)
 }

--- a/internal/modules/auth/repository/session.go
+++ b/internal/modules/auth/repository/session.go
@@ -1,0 +1,50 @@
+package authrepository
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+	authdomain "github.com/vitalfit/api/internal/modules/auth/domain"
+	"gorm.io/gorm"
+)
+
+type SessionStore struct {
+	db *gorm.DB
+}
+
+func NewSessionStore(db *gorm.DB) *SessionStore {
+	return &SessionStore{db: db}
+}
+
+func (s *SessionStore) Create(ctx context.Context, session *authdomain.Session) error {
+	return s.db.WithContext(ctx).Create(session).Error
+
+}
+
+func (s *SessionStore) GetByRefreshToken(refreshToken string) (*authdomain.Session, error) {
+	var session authdomain.Session
+	if err := s.db.Where("refresh_token = ? AND is_blocked = ? AND expires_at > ?",
+		refreshToken, false, time.Now()).First(&session).Error; err != nil {
+		switch err {
+		case gorm.ErrRecordNotFound:
+			return nil, nil
+		default:
+			return nil, err
+		}
+	}
+	return &session, nil
+
+}
+
+func (s *SessionStore) Revoke(sessionID uuid.UUID) error {
+	return s.db.Model(&authdomain.Session{}).
+		Where("id = ?", sessionID).
+		Update("is_blocked", true).Error
+}
+
+func (s *SessionStore) RevokeAllForUser(userID uuid.UUID) error {
+	return s.db.Model(&authdomain.Session{}).
+		Where("user_id = ? AND is_blocked = ?", userID, false).
+		Update("is_blocked", true).Error
+}

--- a/internal/modules/auth/repository/session_repository.go
+++ b/internal/modules/auth/repository/session_repository.go
@@ -2,11 +2,11 @@ package authrepository
 
 import (
 	"context"
-	"errors"
 	"time"
 
 	"github.com/google/uuid"
 	authdomain "github.com/vitalfit/api/internal/modules/auth/domain"
+	shared_errors "github.com/vitalfit/api/internal/shared/errors"
 	"gorm.io/gorm"
 )
 
@@ -47,10 +47,13 @@ func (s *SessionStore) GetUserSessions(ctx context.Context, userID uuid.UUID) ([
 	return sessions, nil
 }
 
-func (s *SessionStore) RotateSession(ctx context.Context, sessionID uuid.UUID, oldToken, newToken string) error {
+func (s *SessionStore) RotateSession(ctx context.Context, sessionID uuid.UUID, oldToken, newToken string, newExpiry time.Time) error {
 	result := s.db.WithContext(ctx).Model(&authdomain.Session{}).
 		Where("id = ? AND refresh_token = ?", sessionID, oldToken).
-		Update("refresh_token", newToken)
+		Updates(map[string]interface{}{
+			"refresh_token": newToken,
+			"expires_at":    newExpiry,
+		})
 
 	if result.Error != nil {
 		return result.Error
@@ -58,7 +61,7 @@ func (s *SessionStore) RotateSession(ctx context.Context, sessionID uuid.UUID, o
 
 	if result.RowsAffected == 0 {
 		// s.db.Model(&authdomain.Session{}).Where("id = ?", sessionID).Update("is_blocked", true)
-		return errors.New("refresh token mismatch: reuse detection")
+		return shared_errors.ErrRefreshTokenMismatch
 	}
 
 	return nil

--- a/internal/modules/auth/repository/session_repository.go
+++ b/internal/modules/auth/repository/session_repository.go
@@ -38,6 +38,19 @@ func (s *SessionStore) GetByRefreshToken(ctx context.Context, refreshToken strin
 
 }
 
+func (s *SessionStore) GetByID(ctx context.Context, sessionID uuid.UUID) (*authdomain.Session, error) {
+	var session authdomain.Session
+	if err := s.db.WithContext(ctx).Where("id = ?", sessionID).First(&session).Error; err != nil {
+		switch err {
+		case gorm.ErrRecordNotFound:
+			return nil, shared_errors.ErrNotFound
+		default:
+			return nil, err
+		}
+	}
+	return &session, nil
+}
+
 func (s *SessionStore) GetUserSessions(ctx context.Context, userID uuid.UUID) ([]*authdomain.Session, error) {
 	var sessions []*authdomain.Session
 	if err := s.db.WithContext(ctx).Where("user_id = ? AND is_blocked = ?", userID, false).

--- a/internal/modules/auth/repository/session_repository.go
+++ b/internal/modules/auth/repository/session_repository.go
@@ -2,6 +2,7 @@ package authrepository
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/google/uuid"
@@ -22,9 +23,9 @@ func (s *SessionStore) Create(ctx context.Context, session *authdomain.Session) 
 
 }
 
-func (s *SessionStore) GetByRefreshToken(refreshToken string) (*authdomain.Session, error) {
+func (s *SessionStore) GetByRefreshToken(ctx context.Context, refreshToken string) (*authdomain.Session, error) {
 	var session authdomain.Session
-	if err := s.db.Where("refresh_token = ? AND is_blocked = ? AND expires_at > ?",
+	if err := s.db.WithContext(ctx).Where("refresh_token = ? AND is_blocked = ? AND expires_at > ?",
 		refreshToken, false, time.Now()).First(&session).Error; err != nil {
 		switch err {
 		case gorm.ErrRecordNotFound:
@@ -37,23 +38,40 @@ func (s *SessionStore) GetByRefreshToken(refreshToken string) (*authdomain.Sessi
 
 }
 
-func (s *SessionStore) GetUserSessions(userID uuid.UUID) ([]*authdomain.Session, error) {
+func (s *SessionStore) GetUserSessions(ctx context.Context, userID uuid.UUID) ([]*authdomain.Session, error) {
 	var sessions []*authdomain.Session
-	if err := s.db.Where("user_id = ? AND is_blocked = ?", userID, false).
+	if err := s.db.WithContext(ctx).Where("user_id = ? AND is_blocked = ?", userID, false).
 		Find(&sessions).Error; err != nil {
 		return nil, err
 	}
 	return sessions, nil
 }
 
-func (s *SessionStore) Revoke(sessionID uuid.UUID) error {
-	return s.db.Model(&authdomain.Session{}).
+func (s *SessionStore) RotateSession(ctx context.Context, sessionID uuid.UUID, oldToken, newToken string) error {
+	result := s.db.WithContext(ctx).Model(&authdomain.Session{}).
+		Where("id = ? AND refresh_token = ?", sessionID, oldToken).
+		Update("refresh_token", newToken)
+
+	if result.Error != nil {
+		return result.Error
+	}
+
+	if result.RowsAffected == 0 {
+		// s.db.Model(&authdomain.Session{}).Where("id = ?", sessionID).Update("is_blocked", true)
+		return errors.New("refresh token mismatch: reuse detection")
+	}
+
+	return nil
+}
+
+func (s *SessionStore) Revoke(ctx context.Context, sessionID uuid.UUID) error {
+	return s.db.WithContext(ctx).Model(&authdomain.Session{}).
 		Where("id = ?", sessionID).
 		Update("is_blocked", true).Error
 }
 
-func (s *SessionStore) RevokeAllForUser(userID uuid.UUID) error {
-	return s.db.Model(&authdomain.Session{}).
+func (s *SessionStore) RevokeAllForUser(ctx context.Context, userID uuid.UUID) error {
+	return s.db.WithContext(ctx).Model(&authdomain.Session{}).
 		Where("user_id = ? AND is_blocked = ?", userID, false).
 		Update("is_blocked", true).Error
 }

--- a/internal/modules/auth/repository/session_repository.go
+++ b/internal/modules/auth/repository/session_repository.go
@@ -37,6 +37,15 @@ func (s *SessionStore) GetByRefreshToken(refreshToken string) (*authdomain.Sessi
 
 }
 
+func (s *SessionStore) GetUserSessions(userID uuid.UUID) ([]*authdomain.Session, error) {
+	var sessions []*authdomain.Session
+	if err := s.db.Where("user_id = ? AND is_blocked = ?", userID, false).
+		Find(&sessions).Error; err != nil {
+		return nil, err
+	}
+	return sessions, nil
+}
+
 func (s *SessionStore) Revoke(sessionID uuid.UUID) error {
 	return s.db.Model(&authdomain.Session{}).
 		Where("id = ?", sessionID).

--- a/internal/modules/auth/services/auth.go
+++ b/internal/modules/auth/services/auth.go
@@ -2,6 +2,7 @@ package authservices
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -222,6 +223,23 @@ func (h *AuthService) UpgradePassword(ctx context.Context, user *authdomain.User
 	return nil
 }
 
+func (h *AuthService) GenerateAccessToken(ctx context.Context, userID uuid.UUID) (string, error) {
+	claims := jwt.MapClaims{
+		"sub": userID,
+		"exp": time.Now().Add(h.config.Auth.Token.AccessExp).Unix(), // Usar config de Access Token
+		"iat": time.Now().Unix(),
+		"nbf": time.Now().Unix(),
+		"iss": h.config.Auth.Token.Iss,
+		"aud": h.config.Auth.Token.Aud,
+	}
+	token, err := h.auth.GenerateToken(claims)
+	if err != nil {
+		return "", err
+	}
+
+	return token, nil
+}
+
 func (h *AuthService) GenerateQrJwtToken(ctx context.Context, user *authdomain.Users) (string, error) {
 	claims := jwt.MapClaims{
 		"sub": user.UserID,
@@ -237,4 +255,52 @@ func (h *AuthService) GenerateQrJwtToken(ctx context.Context, user *authdomain.U
 	}
 
 	return token, nil
+}
+
+func (h *AuthService) GetByRefreshToken(ctx context.Context, refreshToken string) (*authdomain.Session, error) {
+	return h.store.Session.GetByRefreshToken(ctx, refreshToken)
+}
+
+func (h *AuthService) GetUserSessions(ctx context.Context, userID uuid.UUID) ([]*authdomain.Session, error) {
+	return h.store.Session.GetUserSessions(ctx, userID)
+}
+
+func (h *AuthService) RenewAccessToken(ctx context.Context, oldRefreshToken string) (string, string, error) {
+	// 1. Buscar la sesión (sin validar el token específico aún, o usando GetValidSession)
+	// Nota: Si usas GetValidSession del paso anterior, asegúrate de que busque por token exacto.
+	session, err := h.store.Session.GetByRefreshToken(ctx, oldRefreshToken)
+	if err != nil {
+		// Aquí podría caer si el token ya no es el actual (Reuse attempt detectado indirectamente)
+		return "", "", errors.New("invalid session or token reused")
+	}
+
+	// 2. Generar el NUEVO par de tokens
+	newAccessToken, err := h.GenerateAccessToken(ctx, session.UserID) // Extraje lógica a función auxiliar
+	if err != nil {
+		return "", "", err
+	}
+
+	newRefreshToken, err := otp.GenerateRandomString()
+	if err != nil {
+		return "", "", err
+	}
+
+	// 3. ROTACIÓN ATÓMICA
+	// Intentamos cambiar el Viejo por el Nuevo en la DB
+	err = h.store.Session.RotateSession(ctx, session.ID, oldRefreshToken, newRefreshToken)
+	if err != nil {
+		// Si falla la rotación (ej. reuse detection), bloqueamos todo
+		// h.store.Sessions.Revoke(session.ID)
+		return "", "", errors.New("security alert: token reuse detected, session revoked")
+	}
+
+	return newAccessToken, newRefreshToken, nil
+}
+
+func (h *AuthService) Revoke(ctx context.Context, sessionID uuid.UUID) error {
+	return h.store.Session.Revoke(ctx, sessionID)
+}
+
+func (h *AuthService) RevokeAllForUser(ctx context.Context, userID uuid.UUID) error {
+	return h.store.Session.RevokeAllForUser(ctx, userID)
 }

--- a/internal/modules/auth/services/auth.go
+++ b/internal/modules/auth/services/auth.go
@@ -261,6 +261,10 @@ func (h *AuthService) GetByRefreshToken(ctx context.Context, refreshToken string
 	return h.store.Session.GetByRefreshToken(ctx, refreshToken)
 }
 
+func (h *AuthService) GetSessionByID(ctx context.Context, sessionID uuid.UUID) (*authdomain.Session, error) {
+	return h.store.Session.GetByID(ctx, sessionID)
+}
+
 func (h *AuthService) GetUserSessions(ctx context.Context, userID uuid.UUID) ([]*authdomain.Session, error) {
 	return h.store.Session.GetUserSessions(ctx, userID)
 }

--- a/internal/modules/auth/services/auth.go
+++ b/internal/modules/auth/services/auth.go
@@ -11,6 +11,7 @@ import (
 	authdomain "github.com/vitalfit/api/internal/modules/auth/domain"
 	"github.com/vitalfit/api/internal/store"
 	"github.com/vitalfit/api/pkg/mailer"
+	"github.com/vitalfit/api/pkg/otp"
 )
 
 type AuthService struct {
@@ -160,22 +161,40 @@ func (h *AuthService) DeleteResetToken(ctx context.Context, userID uuid.UUID) er
 
 }
 
-func (h *AuthService) GenerateToken(user *authdomain.Users) (string, error) {
-	// generate the token -> add claims
+func (h *AuthService) GenerateToken(ctx context.Context, user *authdomain.Users, userAgent string, clientIP string) (string, string, error) {
 	claims := jwt.MapClaims{
 		"sub": user.UserID,
-		"exp": time.Now().Add(h.config.Auth.Token.Exp).Unix(),
+		"exp": time.Now().Add(h.config.Auth.Token.AccessExp).Unix(), // Usar config de Access Token
 		"iat": time.Now().Unix(),
 		"nbf": time.Now().Unix(),
 		"iss": h.config.Auth.Token.Iss,
 		"aud": h.config.Auth.Token.Aud,
 	}
-	token, err := h.auth.GenerateToken(claims)
+
+	accessToken, err := h.auth.GenerateToken(claims)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
-	return token, nil
+	refreshToken, err := otp.GenerateRandomString()
+	if err != nil {
+		return "", "", err
+	}
+
+	session := &authdomain.Session{
+		UserID:       user.UserID,
+		RefreshToken: refreshToken,
+		UserAgent:    userAgent,
+		ClientIP:     clientIP,
+		IsBlocked:    false,
+		ExpiresAt:    time.Now().Add(h.config.Auth.Token.RefreshExp),
+	}
+
+	if err := h.store.Session.Create(ctx, session); err != nil {
+		return "", "", err
+	}
+
+	return accessToken, refreshToken, nil
 }
 
 func (h *AuthService) ValidateToken(token string) (*jwt.Token, error) {

--- a/internal/modules/auth/services/auth.go
+++ b/internal/modules/auth/services/auth.go
@@ -2,7 +2,6 @@ package authservices
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -10,6 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/vitalfit/api/config"
 	authdomain "github.com/vitalfit/api/internal/modules/auth/domain"
+	shared_errors "github.com/vitalfit/api/internal/shared/errors"
 	"github.com/vitalfit/api/internal/store"
 	"github.com/vitalfit/api/pkg/mailer"
 	"github.com/vitalfit/api/pkg/otp"
@@ -268,10 +268,14 @@ func (h *AuthService) GetUserSessions(ctx context.Context, userID uuid.UUID) ([]
 func (h *AuthService) RenewAccessToken(ctx context.Context, oldRefreshToken string) (string, string, error) {
 	session, err := h.store.Session.GetByRefreshToken(ctx, oldRefreshToken)
 	if err != nil {
-		return "", "", errors.New("invalid session or token reused")
+		return "", "", shared_errors.ErrInvalidSession
 	}
 
-	newAccessToken, err := h.GenerateAccessToken(ctx, session.UserID) // Extraje lógica a función auxiliar
+	if session == nil {
+		return "", "", shared_errors.ErrInvalidSession
+	}
+
+	newAccessToken, err := h.GenerateAccessToken(ctx, session.UserID)
 	if err != nil {
 		return "", "", err
 	}
@@ -281,9 +285,11 @@ func (h *AuthService) RenewAccessToken(ctx context.Context, oldRefreshToken stri
 		return "", "", err
 	}
 
-	err = h.store.Session.RotateSession(ctx, session.ID, oldRefreshToken, newRefreshToken)
+	newExpiry := time.Now().Add(h.config.Auth.Token.RefreshExp)
+
+	err = h.store.Session.RotateSession(ctx, session.ID, oldRefreshToken, newRefreshToken, newExpiry)
 	if err != nil {
-		return "", "", errors.New("security alert: token reuse detected, session revoked")
+		return "", "", shared_errors.ErrTokenReuse
 	}
 
 	return newAccessToken, newRefreshToken, nil

--- a/internal/modules/auth/services/auth.go
+++ b/internal/modules/auth/services/auth.go
@@ -266,15 +266,11 @@ func (h *AuthService) GetUserSessions(ctx context.Context, userID uuid.UUID) ([]
 }
 
 func (h *AuthService) RenewAccessToken(ctx context.Context, oldRefreshToken string) (string, string, error) {
-	// 1. Buscar la sesión (sin validar el token específico aún, o usando GetValidSession)
-	// Nota: Si usas GetValidSession del paso anterior, asegúrate de que busque por token exacto.
 	session, err := h.store.Session.GetByRefreshToken(ctx, oldRefreshToken)
 	if err != nil {
-		// Aquí podría caer si el token ya no es el actual (Reuse attempt detectado indirectamente)
 		return "", "", errors.New("invalid session or token reused")
 	}
 
-	// 2. Generar el NUEVO par de tokens
 	newAccessToken, err := h.GenerateAccessToken(ctx, session.UserID) // Extraje lógica a función auxiliar
 	if err != nil {
 		return "", "", err
@@ -285,12 +281,8 @@ func (h *AuthService) RenewAccessToken(ctx context.Context, oldRefreshToken stri
 		return "", "", err
 	}
 
-	// 3. ROTACIÓN ATÓMICA
-	// Intentamos cambiar el Viejo por el Nuevo en la DB
 	err = h.store.Session.RotateSession(ctx, session.ID, oldRefreshToken, newRefreshToken)
 	if err != nil {
-		// Si falla la rotación (ej. reuse detection), bloqueamos todo
-		// h.store.Sessions.Revoke(session.ID)
 		return "", "", errors.New("security alert: token reuse detected, session revoked")
 	}
 

--- a/internal/modules/auth/services/service_test.go
+++ b/internal/modules/auth/services/service_test.go
@@ -149,7 +149,7 @@ func TestAuthService(t *testing.T) {
 	})
 
 	t.Run("GenerateToken", func(t *testing.T) {
-		token, err := authService.GenerateToken(mockUser)
+		token, _, err := authService.GenerateToken(context.Background(), mockUser, "test-agent", "127.0.0.1")
 		assert.NoError(t, err)
 		assert.NotEmpty(t, token)
 
@@ -163,7 +163,7 @@ func TestAuthService(t *testing.T) {
 	})
 
 	t.Run("ValidateToken", func(t *testing.T) {
-		validToken, _ := authService.GenerateToken(mockUser)
+		validToken, _, _ := authService.GenerateToken(context.Background(), mockUser, "test-agent", "127.0.0.1")
 
 		parsedToken, err := authService.ValidateToken(validToken)
 		assert.NoError(t, err)

--- a/internal/modules/auth/services/service_test.go
+++ b/internal/modules/auth/services/service_test.go
@@ -20,12 +20,16 @@ import (
 	"github.com/vitalfit/api/pkg/pagination"
 )
 
-func setup(t *testing.T) (*authservices.AuthService, *authservices.UserService, *authmocks.UserStoreMock, *authmocks.RoleStoreMock, *mailermocks.MockMailer) {
+func setup(t *testing.T) (*authservices.AuthService, *authservices.UserService, *authmocks.UserStoreMock, *authmocks.RoleStoreMock, *authmocks.SessionStoreMock, *mailermocks.MockMailer) {
 	t.Helper()
 
 	mockStore := store.NewMockStore()
 	userStoreMock := mockStore.Users.(*authmocks.UserStoreMock)
 	roleStoreMock := mockStore.Roles.(*authmocks.RoleStoreMock)
+
+	sessionStoreMock := &authmocks.SessionStoreMock{}
+	mockStore.Session = sessionStoreMock
+
 	cfg := config.LoadConfig()
 	testAuth := &authmocks.TestAuthenticator{}
 	mailer := &mailermocks.MockMailer{}
@@ -33,11 +37,11 @@ func setup(t *testing.T) (*authservices.AuthService, *authservices.UserService, 
 	authService := authservices.NewAuthServices(mockStore, *cfg, testAuth, mailer)
 	userService := authservices.NewUserService(mockStore)
 
-	return authService, userService, userStoreMock, roleStoreMock, mailer
+	return authService, userService, userStoreMock, roleStoreMock, sessionStoreMock, mailer
 }
 
 func TestAuthService(t *testing.T) {
-	authService, _, userStoreMock, roleStoreMock, mailerMock := setup(t)
+	authService, _, userStoreMock, roleStoreMock, sessionStoreMock, mailerMock := setup(t)
 
 	mockUser := &authdomain.Users{
 		UserID:    uuid.New(),
@@ -149,6 +153,7 @@ func TestAuthService(t *testing.T) {
 	})
 
 	t.Run("GenerateToken", func(t *testing.T) {
+		sessionStoreMock.On("Create", mock.Anything, mock.AnythingOfType("*authdomain.Session")).Return(nil).Once()
 		token, _, err := authService.GenerateToken(context.Background(), mockUser, "test-agent", "127.0.0.1")
 		assert.NoError(t, err)
 		assert.NotEmpty(t, token)
@@ -163,6 +168,7 @@ func TestAuthService(t *testing.T) {
 	})
 
 	t.Run("ValidateToken", func(t *testing.T) {
+		sessionStoreMock.On("Create", mock.Anything, mock.AnythingOfType("*authdomain.Session")).Return(nil).Once()
 		validToken, _, _ := authService.GenerateToken(context.Background(), mockUser, "test-agent", "127.0.0.1")
 
 		parsedToken, err := authService.ValidateToken(validToken)
@@ -199,7 +205,7 @@ func TestAuthService(t *testing.T) {
 }
 
 func TestUserService(t *testing.T) {
-	_, userService, userStoreMock, roleStoreMock, _ := setup(t)
+	_, userService, userStoreMock, roleStoreMock, _, _ := setup(t)
 
 	mockUser := &authdomain.Users{
 		UserID:    uuid.New(),

--- a/internal/modules/auth/services/session.go
+++ b/internal/modules/auth/services/session.go
@@ -1,0 +1,1 @@
+package authservices

--- a/internal/modules/auth/services/session.go
+++ b/internal/modules/auth/services/session.go
@@ -1,1 +1,46 @@
 package authservices
+
+import (
+	"context"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	authdomain "github.com/vitalfit/api/internal/modules/auth/domain"
+	"github.com/vitalfit/api/pkg/otp"
+)
+
+func (h *AuthService) CreateUserSession(ctx context.Context, user *authdomain.Users, userAgent, string, clientIP string) (string, string, error) {
+	claims := jwt.MapClaims{
+		"sub": user.UserID,
+		"exp": time.Now().Add(h.config.Auth.Token.AccessExp).Unix(), // Usar config de Access Token
+		"iat": time.Now().Unix(),
+		"nbf": time.Now().Unix(),
+		"iss": h.config.Auth.Token.Iss,
+		"aud": h.config.Auth.Token.Aud,
+	}
+
+	accessToken, err := h.auth.GenerateToken(claims)
+	if err != nil {
+		return "", "", err
+	}
+
+	refreshToken, err := otp.GenerateRandomString()
+	if err != nil {
+		return "", "", err
+	}
+
+	session := &authdomain.Session{
+		UserID:       user.UserID,
+		RefreshToken: refreshToken,
+		UserAgent:    userAgent,
+		ClientIP:     clientIP,
+		IsBlocked:    false,
+		ExpiresAt:    time.Now().Add(h.config.Auth.Token.RefreshExp),
+	}
+
+	if err := h.store.Session.Create(ctx, session); err != nil {
+		return "", "", err
+	}
+
+	return accessToken, refreshToken, nil
+}

--- a/internal/shared/errors/errors.go
+++ b/internal/shared/errors/errors.go
@@ -2,6 +2,7 @@ package errors
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -20,6 +21,9 @@ var (
 	ErrPastClass                = errors.New("cannot book a past class")
 	ErrFullClass                = errors.New("class is full")
 	ErrCancellationWindowClosed = errors.New("cannot cancel booking within the restricted time window")
+	ErrInvalidSession           = errors.New("invalid session or token reused")
+	ErrTokenReuse               = errors.New("security alert: token reuse detected, session revoked")
+	ErrRefreshTokenMismatch     = errors.New("refresh token mismatch: reuse detection")
 )
 
 type LogErrors struct {
@@ -66,7 +70,11 @@ func (l *LogErrors) ForbiddenResponse(c *gin.Context) {
 
 func (l *LogErrors) UnauthorizedErrorResponse(c *gin.Context, err error) {
 	l.logger.Errorw("unauthorized error", "method", c.Request.Method, "path", c.Request.URL.Path, "error", err)
-	c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+	msg := "unauthorized"
+	if err != nil {
+		msg = fmt.Sprintf("unauthorized: %s", err.Error())
+	}
+	c.JSON(http.StatusUnauthorized, gin.H{"error": msg})
 }
 
 func (l *LogErrors) PaymentRequiredResponse(c *gin.Context) {

--- a/internal/store/mocks.go
+++ b/internal/store/mocks.go
@@ -7,8 +7,9 @@ import (
 
 func NewMockStore() Storage {
 	return Storage{
-		Users: authmocks.NewMockUserStore(),
-		Roles: authmocks.NewMockRoleStore(),
-		Audit: auditmocks.NewMockAuditStore(),
+		Users:   authmocks.NewMockUserStore(),
+		Roles:   authmocks.NewMockRoleStore(),
+		Audit:   auditmocks.NewMockAuditStore(),
+		Session: authmocks.NewMockSessionStore(),
 	}
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -62,6 +62,7 @@ type Storage struct {
 	Policies        policiesdomain.PoliciesRepository
 	Wishlist        wishlistdomain.WishlistRepository
 	Audit           auditdomain.AuditRepository
+	Session         authdomain.SessionRepository
 }
 
 func NewStorage(db *gorm.DB) Storage {
@@ -88,5 +89,6 @@ func NewStorage(db *gorm.DB) Storage {
 		Policies:        policiesrepository.NewPoliciesStore(db),
 		Wishlist:        wishlistrepository.NewWishlistStore(db),
 		Audit:           auditrepository.NewAuditStore(db),
+		Session:         authrepository.NewSessionStore(db),
 	}
 }

--- a/pkg/otp/otp.go
+++ b/pkg/otp/otp.go
@@ -1,6 +1,7 @@
 package otp
 
 import (
+	crand "crypto/rand"
 	"encoding/base64"
 	"fmt"
 	"math/rand"
@@ -31,7 +32,7 @@ func GenerateCode(length int) (string, error) {
 
 func GenerateRandomString() (string, error) {
 	b := make([]byte, 32)
-	_, err := rand.Read(b)
+	_, err := crand.Read(b)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/otp/otp.go
+++ b/pkg/otp/otp.go
@@ -1,6 +1,7 @@
 package otp
 
 import (
+	"encoding/base64"
 	"fmt"
 	"math/rand"
 	"time"
@@ -26,4 +27,13 @@ func GenerateCode(length int) (string, error) {
 	}
 
 	return string(code), nil
+}
+
+func GenerateRandomString() (string, error) {
+	b := make([]byte, 32)
+	_, err := rand.Read(b)
+	if err != nil {
+		return "", err
+	}
+	return base64.URLEncoding.EncodeToString(b), nil
 }


### PR DESCRIPTION
### Description

This PR refactors the authentication layer to transition from a purely stateless JWT model to a Stateful Session architecture.

1. Stateful Authentication:

    Migrations: Added database tables to store user sessions.

    Session Management: Implemented logic to persist login sessions in the database (store layer). This allows the backend to track active devices.

2. Rotational Refresh Tokens:

    Security Upgrade: Implemented Token Rotation. Now, every time a Refresh Token is used to get a new Access Token, the old Refresh Token is invalidated/deleted and a new one is issued.

    Expiration: Updated the configuration for token expiration times to align with the rotation policy.

3. Permissions:

    Updated permission checks to control who can view or manage (revoke) these active sessions.

### Related Issue

N/A
### Motivation and Context

    Security Control: Pure stateless JWTs cannot be easily revoked if a device is stolen or a user is banned. By moving to stateful sessions, we can now manually revoke specific sessions (force logout) from the server side.

    Theft Prevention: Rotational Refresh Tokens significantly reduce the risk of token theft. If a refresh token is stolen, it becomes useless as soon as the legitimate user (or the attacker) uses it, as the chain is broken.

### How Has This Been Tested?

    Login Flow: Verified that logging in successfully creates a new session record in the database.

    Refresh Flow: Performed a token refresh and verified that:

        A new Access Token is received.

        A new Refresh Token is received.

        The old Refresh Token is marked as invalid/deleted in the DB.

    Revocation: Tested that deleting a session record in the DB immediately causes subsequent requests (using that session's token) to fail with a 401.