### PR TITLE
fix(products): Handle upsert and soft-delete recovery in AssignBranchService

### DIFF
--- a/internal/modules/products/repository/branch_product_repository.go
+++ b/internal/modules/products/repository/branch_product_repository.go
@@ -20,7 +20,16 @@ func (s *ProductsStore) AssignBranchService(ctx context.Context, branchServices 
 	}
 	err := db.WithTX(s.db, func(tx *gorm.DB) error {
 		if err := tx.WithContext(ctx).
-			Clauses(clause.OnConflict{DoNothing: true}).
+			Clauses(clause.OnConflict{
+				Columns: []clause.Column{{Name: "service_id"}, {Name: "branch_id"}},
+				DoUpdates: clause.AssignmentColumns([]string{
+					"is_visible",
+					"max_capacity",
+					"price_for_member",
+					"price_for_non_member",
+					"deleted_at",
+				}),
+			}).
 			Create(&branchServices).Error; err != nil {
 			return err
 		}


### PR DESCRIPTION
Description

This PR modifies the AssignBranchService repository method to handle conflicts correctly.

    Change: Switched from Clauses(clause.OnConflict{DoNothing: true}) to an Upsert strategy (DoUpdates).

    Behavior: Now, if a service assignment already exists (unique constraint on service_id + branch_id), the system will update the record instead of ignoring the request.

    Key Fix: Explicitly included deleted_at in the update columns. This allows previously soft-deleted assignments to be "resurrected" (re-enabled) when a user tries to assign them again.

Related Issue

N/A
Motivation and Context

    The Bug: If a Branch Admin deleted a service from their branch (Soft Delete) and later tried to add it back, the operation would silently fail. The database saw the record existed (even if deleted) and DoNothing prevented any changes.

    The Resolution: By using DoUpdates, we ensure that re-adding a service overwrites the old status, clearing the deleted_at timestamp and updating any price/capacity changes.

How Has This Been Tested?

    Re-activation Scenario:

        Assigned a service to a branch.

        Deleted the service from the branch (verified deleted_at was set).

        Attempted to assign the same service again.

        Result: Verified that the record's deleted_at became NULL and the service is visible again.

    Update Scenario: Verified that assigning an existing service with a new price correctly updates the price instead of throwing a duplicate key error.