### PR TITLE
fix(llm): Correct JSON Schema for parameterless OpenAI tools

### DIFF
--- a/internal/modules/llm/services/tools.go
+++ b/internal/modules/llm/services/tools.go
@@ -22,9 +22,9 @@ var tools = []openai.Tool{
 		Function: &openai.FunctionDefinition{
 			Name:        "get_all_branches",
 			Description: "Obtiene la lista de todas las sucursales disponibles con sus IDs. Útil cuando el usuario quiere saber qué sucursales existen o para obtener el ID de una sucursal por su nombre.",
-			Parameters: jsonschema.Definition{
-				Type:       jsonschema.Object,
-				Properties: map[string]jsonschema.Definition{},
+			Parameters: map[string]interface{}{
+				"type":       "object",
+				"properties": map[string]interface{}{},
 			},
 		},
 	},
@@ -71,9 +71,9 @@ var tools = []openai.Tool{
 		Function: &openai.FunctionDefinition{
 			Name:        "get_my_bookings",
 			Description: "Obtiene la lista de reservas activas del usuario. Útil para ver qué tiene reservado o para buscar el ID de una reserva para cancelar.",
-			Parameters: jsonschema.Definition{
-				Type:       jsonschema.Object,
-				Properties: map[string]jsonschema.Definition{},
+			Parameters: map[string]interface{}{
+				"type":       "object",
+				"properties": map[string]interface{}{},
 			},
 		},
 	},


### PR DESCRIPTION
### Description

This PR fixes the Parameters definition for OpenAI tools that require no arguments (specifically get_all_branches and get_my_bookings).

    Change: Replaced the typed jsonschema.Definition struct with a raw map[string]interface{}.

    Reason: The OpenAI API requires a strict JSON structure of {"type": "object", "properties": {}} for functions with no parameters. The previous struct implementation was likely serializing incorrectly (or omitting fields), causing the API to reject the tool definition or fail to invoke it.

### Related Issue

N/A
### Motivation and Context

    API Compliance: Without this fix, the LLM might hallucinate arguments or fail to call the get_all_branches tool entirely because the schema didn't match the expected format for "no parameters".

### How Has This Been Tested?

    Tool Invocation: Verified that asking "What branches are there?" now successfully triggers the get_all_branches tool without the API throwing a schema validation error.