### PR TITLE
fix(llm): Enable Iterative Tool Chaining (Multi-Step Reasoning)

### DIFF
--- a/internal/modules/llm/services/llm_services.go
+++ b/internal/modules/llm/services/llm_services.go
@@ -104,7 +104,8 @@ Directrices:
 
 	msg := resp.Choices[0].Message
 
-	if len(msg.ToolCalls) > 0 {
+	// Usamos un bucle (máx 5 iteraciones) para permitir que el LLM encadene herramientas (ej: get_branches -> get_classes)
+	for i := 0; i < 5 && len(msg.ToolCalls) > 0; i++ {
 		openaiMsgs = append(openaiMsgs, msg)
 
 		for _, toolCall := range msg.ToolCalls {


### PR DESCRIPTION
### Description

This PR updates the LLM service logic to support Multi-Turn Tool Execution.

    Logic Change: Replaced the single if len(msg.ToolCalls) > 0 check with a for loop (limited to 5 iterations).

    Behavior: The system now allows the AI to:

        Call a tool (e.g., get_all_branches).

        Receive the result.

        Decide to call another tool based on that result (e.g., get_available_classes using the ID found in step 1).

        Repeat until the AI generates a final text response or hits the loop limit.

### Related Issue

N/A
### Motivation and Context

    The Bug: Previously, the AI could only execute one round of tools. If a user asked "Book the next Yoga class at the Downtown branch", the AI would fail because it needs to find the "Downtown" branch ID first. It would execute get_all_branches and then immediately stop or return the raw JSON list to the user without proceeding to the booking step.

    The Fix: This loop enables Sequential Reasoning, allowing the AI to perform the necessary chain of lookup -> action -> confirmation.

### How Has This Been Tested?

    Multi-Step Prompt: Asked the bot: "Who is the instructor for the 5 PM class at the 'Central' branch?"

        Expected behavior: The bot calls get_all_branches (Step 1), finds the ID for 'Central', then calls get_available_classes (Step 2) with that ID, and finally answers the user.

        Result: Verified in logs that the loop ran twice and produced the correct final answer.

    Safety Limit: Verified that the loop terminates after 5 iterations to prevent infinite loops if the AI gets stuck calling the same tool repeatedly.