### PR TITLE
fix(llm): Enhance Agent Context, Tool Self-Correction & Response Filtering

### DIFF
--- a/internal/modules/llm/services/llm_services.go
+++ b/internal/modules/llm/services/llm_services.go
@@ -72,7 +72,8 @@ Directrices:
 3. Si te piden clases para "hoy" o "mañana", usa la fecha actual como referencia.
 4. Si falta información (como IDs de sucursal o clase), NO se los pidas al usuario. Usa 'get_all_branches' o 'get_available_classes' para buscar la información necesaria por nombre o contexto.
 5. Cuando listes clases, muestra la hora, actividad e instructor, pero NO muestres el ID técnico al usuario.
-6. Si el usuario quiere reservar una clase por hora (ej. "la de las 19:00"), busca el ID internamente en el listado de clases y usa la herramienta 'book_class'.`, time.Now().Format("2006-01-02 15:04"))
+6. Si el usuario quiere reservar una clase por nombre u hora (ej. "la de yoga"), busca el ID correspondiente en los resultados de las herramientas anteriores (historial) y usa 'book_class'.
+7. Si una herramienta falla por falta de parámetros, intenta obtenerlos con otra herramienta antes de rendirte.`, time.Now().Format("2006-01-02 15:04"))
 
 	openaiMsgs = append(openaiMsgs, openai.ChatCompletionMessage{
 		Role:    openai.ChatMessageRoleSystem,

--- a/internal/modules/llm/services/tools.go
+++ b/internal/modules/llm/services/tools.go
@@ -45,7 +45,6 @@ var tools = []openai.Tool{
 						Description: "El UUID de la sucursal para consultar el horario.",
 					},
 				},
-				Required: []string{"branch_id"},
 			},
 		},
 	},
@@ -188,9 +187,13 @@ func (s *LLMService) callFunction(ctx context.Context, userID uuid.UUID, name st
 		startOfDay := time.Date(targetDate.Year(), targetDate.Month(), targetDate.Day(), 0, 0, 0, 0, targetDate.Location())
 		endOfDay := startOfDay.Add(24 * time.Hour)
 
+		if args.BranchID == "" {
+			return s.callFunction(ctx, userID, "get_all_branches", "{}")
+		}
+
 		branchID, err := uuid.Parse(args.BranchID)
 		if err != nil {
-			return "Error: ID de sucursal inválido.", nil
+			return "Error: ID de sucursal inválido. Por favor usa 'get_all_branches' para obtener un ID válido.", nil
 		}
 
 		classes, err := s.store.Schedule.GetClassesByBranch(ctx, branchID, &startOfDay, &endOfDay)

--- a/internal/modules/llm/services/tools.go
+++ b/internal/modules/llm/services/tools.go
@@ -289,13 +289,28 @@ func (s *LLMService) callFunction(ctx context.Context, userID uuid.UUID, name st
 		if err != nil {
 			return "Error obteniendo tus reservas.", nil
 		}
-		if len(bookings) == 0 {
-			return "No tienes ninguna reserva activa en este momento.", nil
+
+		// Filtramos solo las reservas futuras para no saturar el contexto del LLM
+		var upcoming []bookingdomain.BookingWithClassInfo
+		now := time.Now()
+		for _, b := range bookings {
+			if b.StartsAt.After(now) {
+				upcoming = append(upcoming, b)
+			}
+		}
+
+		if len(upcoming) == 0 {
+			return "No tienes ninguna reserva futura en este momento.", nil
+		}
+
+		// Limitamos a 10 para evitar errores de tokens
+		if len(upcoming) > 10 {
+			upcoming = upcoming[:10]
 		}
 
 		var result strings.Builder
-		result.WriteString("Tus reservas activas son:\n")
-		for _, b := range bookings {
+		result.WriteString("Tus próximas reservas son:\n")
+		for _, b := range upcoming {
 			result.WriteString(fmt.Sprintf("- ID: %s | %s con %s - %s (%s)\n", b.BookingID, b.ServiceName, b.Instructor, b.StartsAt.Format("Mon, 02 Jan 15:04"), b.BranchName))
 		}
 		return result.String(), nil


### PR DESCRIPTION
### Description

This PR optimizes how the AI Agent handles missing parameters and manages its context window size.

1. Tool Self-Correction (Logic Fix):

    Branch Lookup Fallback: Modified get_available_classes. If the AI calls this tool without providing a branch_id, the system now automatically triggers get_all_branches internally and returns that list.

        Benefit: Instead of returning a hard error ("Invalid ID"), it returns the information the AI needs to fix its mistake, allowing it to recover and succeed in the next loop iteration.

2. Context Window Optimization:

    Booking Filtering: Updated get_my_bookings to:

        Filter out past bookings (only showing future/upcoming classes).

        Limit the result to the top 10 entries.

        Benefit: This prevents sending massive JSON blobs of historical data to OpenAI, saving tokens and keeping the AI focused on relevant info.

3. Prompt Engineering:

    Refined the System Prompt to explicitly instruct the bot on how to handle missing IDs (look in history first) and how to search for classes by context (e.g., "yoga") instead of asking the user for technical UUIDs.

### Related Issue

N/A
### Motivation and Context

    Error Recovery: The Agent was previously getting stuck if it didn't know the Branch ID. The new logic makes it "smart enough" to ask for the list implicitly.

    Cost & Performance: Users with long booking histories were causing the LLM to hit token limits or hallucinate due to "noise" in the context. Filtering strictly to future events solves this.

### How Has This Been Tested?

    Missing Parameter Test:

        Asked: "What classes are available today?" (Intentionally omitting the branch).

        Result: The tool returned the list of branches. The AI then asked me "Which branch?", or picked one if context implied it.

    Context Limit Test:

        Logged in as a user with 50 past bookings.

        Asked: "What do I have booked?"

        Result: The response contained only the 2 upcoming classes, ignoring the 48 past ones.