### PR TITLE
feat(llm): Auto-fetch branches when Branch ID is missing

### DIFF
--- a/internal/modules/llm/services/llm_services.go
+++ b/internal/modules/llm/services/llm_services.go
@@ -73,7 +73,8 @@ Directrices:
 4. Si falta información (como IDs de sucursal o clase), NO se los pidas al usuario. Usa 'get_all_branches' o 'get_available_classes' para buscar la información necesaria por nombre o contexto.
 5. Cuando listes clases, muestra la hora, actividad e instructor, pero NO muestres el ID técnico al usuario.
 6. Si el usuario quiere reservar una clase por nombre u hora (ej. "la de yoga"), busca el ID correspondiente en los resultados de las herramientas anteriores (historial) y usa 'book_class'.
-7. Si una herramienta falla por falta de parámetros, intenta obtenerlos con otra herramienta antes de rendirte.`, time.Now().Format("2006-01-02 15:04"))
+7. Si una herramienta falla por falta de parámetros, intenta obtenerlos con otra herramienta antes de rendirte.
+8. Si el usuario quiere cancelar una reserva, NUNCA pidas el ID. Usa 'get_my_bookings' para ver qué tiene reservado. Si es una solicitud genérica, lista las opciones. Si es específica, busca el ID y confirma.`, time.Now().Format("2006-01-02 15:04"))
 
 	openaiMsgs = append(openaiMsgs, openai.ChatCompletionMessage{
 		Role:    openai.ChatMessageRoleSystem,

--- a/internal/modules/llm/services/tools.go
+++ b/internal/modules/llm/services/tools.go
@@ -152,7 +152,7 @@ var tools = []openai.Tool{
 }
 
 func (s *LLMService) callFunction(ctx context.Context, userID uuid.UUID, name string, argsRaw string) (string, error) {
-	s.logger.Infow("🔧 Ejecutando Tool", "name", name, "args", argsRaw)
+	s.logger.Infow(" Ejecutando Tool", "name", name, "args", argsRaw)
 
 	switch name {
 	case "get_all_branches":

--- a/internal/modules/llm/services/tools.go
+++ b/internal/modules/llm/services/tools.go
@@ -188,7 +188,8 @@ func (s *LLMService) callFunction(ctx context.Context, userID uuid.UUID, name st
 		endOfDay := startOfDay.Add(24 * time.Hour)
 
 		if args.BranchID == "" {
-			return s.callFunction(ctx, userID, "get_all_branches", "{}")
+			branchesOutput, _ := s.callFunction(ctx, userID, "get_all_branches", "{}")
+			return fmt.Sprintf("Falta el ID de la sucursal. Aquí tienes las disponibles para que el usuario elija:\n%s", branchesOutput), nil
 		}
 
 		branchID, err := uuid.Parse(args.BranchID)


### PR DESCRIPTION
### Description

This PR implements a "Self-Correction" mechanism for the AI's schedule lookup tool.

    Behavior Change: In get_available_classes, if the branch_id parameter is empty or missing, the system now intercepts the call.

    Automatic Fallback: Instead of returning an error, it recursively calls get_all_branches internally and returns that list to the AI.

    Result: The AI receives the list of branches immediately, allowing it to realize its mistake and ask the user for the specific branch (or pick one from context) in the very next step, without crashing or outputting a "System Error".

### Related Issue

N/A
### Motivation and Context

    Robustness: The LLM frequently attempts to call get_available_classes prematurely (before knowing the branch ID). Previously, this resulted in a dead-end error. This change makes the Agent "fail forward" by giving it the data it needs to fix the problem.

### How Has This Been Tested?

    Empty ID Test: Called the tool with {"branch_id": ""}.

        Previous result: Error: Invalid UUID.

        New result: JSON list of all available branches.