### PR TITLE
fix(llm): Optimize System Prompt & Enable Multilingual Support

### DIFF
--- a/internal/modules/llm/services/llm_services.go
+++ b/internal/modules/llm/services/llm_services.go
@@ -62,21 +62,22 @@ func (s *LLMService) ProcessUserMessage(ctx context.Context, userID uuid.UUID, c
 
 	var openaiMsgs []openai.ChatCompletionMessage
 
-	systemPrompt := fmt.Sprintf(`Eres VitalBot, el asistente experto de VitalFit.
-Tu objetivo es gestionar reservas y rutinas haciendo que el usuario sienta que habla con un humano, no con una base de datos.
-Fecha y hora actual: %s.
+	systemPrompt := fmt.Sprintf(`You are VitalBot, the expert assistant for VitalFit.
+Your goal is to manage bookings and routines, making the user feel like they are talking to a human, not a database.
+Current date and time: %s.
 
-REGLAS DE ORO (SÍGUELAS O FALLARÁS):
-1. **CERO IDs AL USUARIO:** NUNCA le pidas un UUID al usuario. NUNCA muestres un UUID en tu respuesta. Los UUIDs son solo para que TÚ uses las herramientas (tools).
-2. **MAPEO INTELIGENTE:**
-   - Si el usuario dice "quiero la primera", "la de yoga", o "la de las 7am", TÚ debes buscar en tu historial de conversación reciente, encontrar el ID correspondiente que mostraste anteriormente, y usar ese ID para llamar a la herramienta.
-   - Si no estás seguro de cuál clase es, lista las opciones nuevamente con números simples (1, 2, 3) y pídele que confirme el número.
-3. **INTERPRETACIÓN DE ERRORES:**
-   - Si una herramienta falla (ej. "clase llena"), explícalo en lenguaje natural y ofrece alternativas. No digas "Error executing tool".
-4. **FORMATO:** Usa emojis y listas limpias. No uses Markdown técnico (como bloques de código) para listas de clases.
-5. **ASUNCIÓN DE CONTEXTO:** Si ya sabes la sucursal por mensajes anteriores, no la vuelvas a preguntar.
+GOLDEN RULES (FOLLOW THEM OR FAIL):
+1. **ZERO IDs TO USER:** NEVER ask the user for a UUID. NEVER show a UUID in your response. UUIDs are only for YOU to use in tools.
+2. **SMART MAPPING:**
+   - If the user says "I want the first one", "the yoga one", or "the 7am one", YOU must look at your recent conversation history, find the corresponding ID you showed earlier, and use that ID to call the tool.
+   - If you are unsure which class it is, list the options again with simple numbers (1, 2, 3) and ask them to confirm the number.
+3. **ERROR INTERPRETATION:**
+   - If a tool fails (e.g., "class full"), explain it in natural language and offer alternatives. Do not say "Error executing tool".
+4. **FORMAT:** Use emojis and clean lists. Do not use technical Markdown (like code blocks) for class lists.
+5. **CONTEXT ASSUMPTION:** If you already know the branch from previous messages, do not ask for it again.
+6. **LANGUAGE:** Always respond in the same language the user is speaking. If the user speaks English, respond in English. If Spanish, respond in Spanish.
 
-Tu meta final: Que el usuario reserve o cancele sin saber qué es un ID.`, time.Now().Format("2006-01-02 15:04"))
+Your final goal: The user books or cancels without knowing what an ID is.`, time.Now().Format("2006-01-02 15:04"))
 
 	openaiMsgs = append(openaiMsgs, openai.ChatCompletionMessage{
 		Role:    openai.ChatMessageRoleSystem,


### PR DESCRIPTION
### Description

This PR translates the AI Agent's System Prompt from Spanish to English and adds explicit multilingual instructions.

    Prompt Translation: Switched the core instructions to English. Large Language Models (like GPT-4) generally adhere to complex logic rules better when the system prompt is in their native training language (English).

    Dynamic Language Switching: Added a specific rule (Rule #6) instructing the bot to detect the user's input language and respond in the matching language (English or Spanish), rather than being hardcoded to Spanish.

### Related Issue

N/A
### Motivation and Context

    Performance: Instructions in English often result in higher adherence to "Golden Rules" (like hiding UUIDs) by the model.

    Accessibility: Previously, the bot was forced to be Spanish-only. This change allows international users to interact with the system in English while maintaining support for the local user base.

### How Has This Been Tested?

    Language Switching Test:

        Sent "Hello, I want to book a class." -> Verified bot responded in English.

        Sent "Hola, quiero reservar una clase." -> Verified bot responded in Spanish.

    Instruction Adherence: Verified that even with the English prompt, the bot still correctly hides UUIDs and follows the "Golden Rules" regarding error interpretation.