### PR TITLE
fix(inventory): Explicitly define GORM table names for Equipment

### DIFF
--- a/internal/modules/inventory/domain/equipment.go
+++ b/internal/modules/inventory/domain/equipment.go
@@ -31,6 +31,10 @@ type Equipment struct {
 	DeletedAt   gorm.DeletedAt        `gorm:"index" json:"deleted_at,omitempty" swaggertype:"primitive,string"`
 }
 
+func (Equipment) TableName() string {
+	return "equipment"
+}
+
 type EquipmentQueryResults struct {
 	Equipments []*Equipment
 }

--- a/internal/modules/inventory/domain/inventory.go
+++ b/internal/modules/inventory/domain/inventory.go
@@ -29,3 +29,7 @@ type BranchInventory struct {
 	DeletedAt           gorm.DeletedAt      `gorm:"index" json:"deleted_at,omitempty" swaggertype:"primitive,string"`
 	Equipment           *Equipment          `gorm:"foreignKey:EquipmentID;references:EquipmentID" json:"equipment,omitempty"`
 }
+
+func (BranchInventory) TableName() string {
+	return "branch_inventory"
+}


### PR DESCRIPTION
Description

This PR forces GORM to use specific table names for the Inventory module entities.

    Changes: Added TableName() methods to the Equipment and BranchInventory structs.

    Mapping:

        Equipment -> "equipment" (Overrides default pluralization which might look for equipments).

        BranchInventory -> "branch_inventory" (Overrides default branch_inventories).

Related Issue

N/A
Motivation and Context

    ORM Stability: GORM's default behavior attempts to pluralize struct names (e.g., turning Equipment into equipments). If the actual database table is named singular equipment, queries fail with "relation does not exist" errors.

    Fix: Hardcoding the table name ensures the API interacts with the correct database tables regardless of GORM's naming conventions.

How Has This Been Tested?

    Query Test: Ran the GetBranchInventory endpoint. Verified that GORM generated the SQL SELECT * FROM "branch_inventory" ... instead of trying to access non-existent tables.