### PR TITLE
fix(llm): Enforce UUID usage over List Indexes in Tool Calls

### DIFF
--- a/internal/modules/inventory/repository/branch_inventory_repository.go
+++ b/internal/modules/inventory/repository/branch_inventory_repository.go
@@ -43,9 +43,11 @@ func (s *BranchInventoryStore) Create(ctx context.Context, item *inventorydomain
 func (s *BranchInventoryStore) GetByBranch(ctx context.Context, branchID uuid.UUID) ([]inventorydomain.BranchInventory, error) {
 	var inventory []inventorydomain.BranchInventory
 	err := s.db.WithContext(ctx).
-		Where("branch_id = ?", branchID).
+		Joins("JOIN equipment ON equipment.equipment_id = branch_inventory.equipment_id").
+		Where("branch_inventory.branch_id = ?", branchID).
+		Where("equipment.deleted_at IS NULL").
 		Preload("Equipment").
-		Order("created_at desc").
+		Order("branch_inventory.created_at desc").
 		Find(&inventory).Error
 	if err != nil {
 		return nil, err

--- a/internal/modules/inventory/repository/branch_inventory_repository.go
+++ b/internal/modules/inventory/repository/branch_inventory_repository.go
@@ -43,11 +43,11 @@ func (s *BranchInventoryStore) Create(ctx context.Context, item *inventorydomain
 func (s *BranchInventoryStore) GetByBranch(ctx context.Context, branchID uuid.UUID) ([]inventorydomain.BranchInventory, error) {
 	var inventory []inventorydomain.BranchInventory
 	err := s.db.WithContext(ctx).
-		Joins("JOIN equipment ON equipment.equipment_id = branch_inventory.equipment_id").
-		Where("branch_inventory.branch_id = ?", branchID).
-		Where("equipment.deleted_at IS NULL").
-		Preload("Equipment").
-		Order("branch_inventory.created_at desc").
+		Where("branch_id = ?", branchID).
+		Preload("Equipment", func(db *gorm.DB) *gorm.DB {
+			return db.Unscoped()
+		}).
+		Order("created_at desc").
 		Find(&inventory).Error
 	if err != nil {
 		return nil, err

--- a/internal/modules/llm/services/llm_services.go
+++ b/internal/modules/llm/services/llm_services.go
@@ -69,7 +69,10 @@ Current date and time: %s.
 GOLDEN RULES (FOLLOW THEM OR FAIL):
 1. **ZERO IDs TO USER:** NEVER ask the user for a UUID. NEVER show a UUID in your response. UUIDs are only for YOU to use in tools.
 2. **SMART MAPPING:**
-   - If the user says "I want the first one", "the yoga one", or "the 7am one", YOU must look at your recent conversation history, find the corresponding ID you showed earlier, and use that ID to call the tool.
+   - The user sees a simple numbered list (1, 2, 3...).
+   - You see the UUIDs in the tool outputs (e.g., "[ID: 123...]").
+   - IF the user selects "1", YOU MUST find the UUID for item #1 and use THAT UUID in the tool call.
+   - NEVER send "1", "2", etc. as an ID to a tool.
    - If you are unsure which class it is, list the options again with simple numbers (1, 2, 3) and ask them to confirm the number.
 3. **ERROR INTERPRETATION:**
    - If a tool fails (e.g., "class full"), explain it in natural language and offer alternatives. Do not say "Error executing tool".

--- a/internal/modules/llm/services/tools.go
+++ b/internal/modules/llm/services/tools.go
@@ -209,7 +209,7 @@ func (s *LLMService) callFunction(ctx context.Context, userID uuid.UUID, name st
 		}
 
 		var result strings.Builder
-		result.WriteString(fmt.Sprintf("SYSTEM NOTE: Do not show the IDs to the user. Use them internally for booking. Available classes for %s:\n", targetDate.Format("2006-01-02")))
+		result.WriteString(fmt.Sprintf("SYSTEM NOTE: The user sees a numbered list. You MUST map the user's selection (e.g., '1') to the corresponding UUID provided in brackets [ID:...] when calling tools. Available classes for %s:\n", targetDate.Format("2006-01-02")))
 
 		count := 0
 		for _, c := range classes {
@@ -256,7 +256,7 @@ func (s *LLMService) callFunction(ctx context.Context, userID uuid.UUID, name st
 
 		classID, err := uuid.Parse(args.ClassID)
 		if err != nil {
-			return "Error: El ID de la clase no es válido.", nil
+			return fmt.Sprintf("Error: '%s' is not a valid UUID. You sent the list number instead of the UUID. Please retrieve the UUID corresponding to item #%s from the available classes list and try again.", args.ClassID, args.ClassID), nil
 		}
 
 		class, err := s.store.Schedule.GetClassByID(ctx, classID)
@@ -343,7 +343,7 @@ func (s *LLMService) callFunction(ctx context.Context, userID uuid.UUID, name st
 		var result strings.Builder
 		result.WriteString("Tus próximas reservas son:\n")
 		for _, b := range upcoming {
-			result.WriteString(fmt.Sprintf("- ID: %s | %s con %s - %s (%s)\n", b.BookingID, b.ServiceName, b.Instructor, b.StartsAt.Format("Mon, 02 Jan 15:04"), b.BranchName))
+			result.WriteString(fmt.Sprintf("- [ID:%s] %s con %s - %s (%s)\n", b.BookingID, b.ServiceName, b.Instructor, b.StartsAt.Format("Mon, 02 Jan 15:04"), b.BranchName))
 		}
 		return result.String(), nil
 
@@ -356,7 +356,7 @@ func (s *LLMService) callFunction(ctx context.Context, userID uuid.UUID, name st
 		}
 		bookingID, err := uuid.Parse(args.BookingID)
 		if err != nil {
-			return "Error: ID de reserva inválido.", nil
+			return fmt.Sprintf("Error: '%s' is not a valid UUID. You sent the list number instead of the UUID. Please retrieve the UUID corresponding to the booking from the list and try again.", args.BookingID), nil
 		}
 
 		if err := s.store.Booking.CancelBooking(ctx, bookingID); err != nil {


### PR DESCRIPTION
Description

This PR fixes a common hallucination where the AI Agent attempts to call tools using the visual list index (e.g., "1", "2") instead of the required database UUID.

1. System Prompt Engineering:

    Added explicit "Smart Mapping" rules. The AI is now instructed that while the user sees a numbered list (1, 2, 3), the Agent must look up the corresponding UUID provided in the tool output brackets [ID:...].

    Explicitly forbids sending integers to book_class or cancel_booking.

2. Self-Correction Error Messages:

    Logic: Modified the uuid.Parse error handling in the tool execution layer.

    The Fix: If the AI sends an invalid ID (like "1"), the system now returns a specific prompt: "Error: '1' is not a valid UUID. You sent the list number... Please retrieve the UUID...".

    Impact: This allows the AI to catch its own mistake and retry with the correct ID in the same conversation loop.

3. Output Formatting:

    Updated get_my_bookings and get_available_classes to ensure the UUID is clearly labeled as [ID: xxxxx] in the text injected into the context window, making it easier for the model to "scrape" the correct key.

Related Issue

N/A
Motivation and Context

    The Bug: Users would say "Book the first option," and the AI would call book_class(class_id="1"), causing the backend to crash or return a generic error.

    The Fix: This change creates a robust "translation layer" where the AI understands the difference between the User's UI (numbers) and the System's API (UUIDs).

How Has This Been Tested?

    Index Selection Test:

        Asked: "Show me classes for today."

        Bot listed 3 classes: 1. Yoga, 2. Pilates, 3. Box.

        Replied: "Book number 2".

        Result: Verified logs showed the AI called book_class with the UUID of the Pilates class, not the number "2".

    Error Recovery Test:

        Manually forced a tool call with class_id="1".

        Result: The system returned the specific error message, and the AI immediately followed up with a corrected call using the valid UUID.