### PR TITLE
fix(booking): Filter out Cancelled Bookings from Client History

### DIFF
--- a/internal/modules/booking/repository/booking_repository.go
+++ b/internal/modules/booking/repository/booking_repository.go
@@ -176,7 +176,7 @@ func (s *BookingStore) CountBookingsForClass(ctx context.Context, classID uuid.U
 
 func (s *BookingStore) GetClientBookings(ctx context.Context, userID uuid.UUID, startDate, endDate *time.Time) ([]bookingdomain.BookingWithClassInfo, error) {
 	var results []bookingdomain.BookingWithClassInfo
-	args := []interface{}{userID}
+	args := []interface{}{userID, bookingdomain.BookingStatusCancelledByUser, bookingdomain.BookingStatusCancelledBySystem}
 
 	queryStr := `
         SELECT 
@@ -193,7 +193,7 @@ func (s *BookingStore) GetClientBookings(ctx context.Context, userID uuid.UUID, 
         JOIN instructors ins ON c.instructor_id = ins.instructor_id
         JOIN users u ON ins.user_id = u.user_id
         JOIN branch br ON c.branch_id = br.branch_id
-        WHERE b.user_id = ? AND b.deleted_at IS NULL
+        WHERE b.user_id = ? AND b.deleted_at IS NULL AND b.status NOT IN (?, ?)
     `
 
 	if startDate != nil {


### PR DESCRIPTION
Description

This PR updates the GetClientBookings repository method to exclude cancelled bookings from the result set.

    Logic Change: Updated the raw SQL query to include a WHERE clause filtering out bookings with status CancelledByUser or CancelledBySystem.

    Result: The "My Bookings" list now only displays active (Confirmed) or past (Attended) sessions, removing the clutter of cancelled classes.

Related Issue

N/A
Motivation and Context

    User Experience: Clients were confused seeing classes they had cancelled still appearing in their "Active/Upcoming" list. This fix ensures the list accurately reflects their actual schedule commitments.

    AI Agent Accuracy: This also implicitly fixes an issue where the AI Agent (which uses this tool) might have told a user "You have a booking for X" when they had actually cancelled it.

How Has This Been Tested?

    Cancellation Flow:

        Booked a class.

        Verified it appeared in the list.

        Cancelled the class.

        Called GetClientBookings again.

        Result: The cancelled class was no longer present in the returned list.