### PR TITLE
fix(stripe): Update Webhook Compatibility & Checkout Redirect URLs

### DIFF
--- a/internal/modules/billing/service/billing_service.go
+++ b/internal/modules/billing/service/billing_service.go
@@ -120,7 +120,9 @@ func (bs *BillingService) CreateCheckoutSessionForInvoice(ctx context.Context, i
 }
 
 func (bs *BillingService) HandleStripeWebhook(ctx context.Context, body []byte, signature string) error {
-	event, err := webhook.ConstructEvent(body, signature, bs.cfg.Stripe.WebhookSecret)
+	event, err := webhook.ConstructEventWithOptions(body, signature, bs.cfg.Stripe.WebhookSecret, webhook.ConstructEventOptions{
+		IgnoreAPIVersionMismatch: true,
+	})
 	if err != nil {
 		return fmt.Errorf("webhook signature verification failed: %v", err)
 	}

--- a/internal/modules/billing/service/billing_service.go
+++ b/internal/modules/billing/service/billing_service.go
@@ -96,8 +96,8 @@ func (bs *BillingService) CreateCheckoutSessionForInvoice(ctx context.Context, i
 		baseURL = "http://" + baseURL
 	}
 
-	successURL := fmt.Sprintf("%s/payment/%s?status=success", baseURL, invoice.InvoiceID.String())
-	cancelURL := fmt.Sprintf("%s/payment/%s?status=cancelled", baseURL, invoice.InvoiceID.String())
+	successURL := fmt.Sprintf("%s/payments/%s", baseURL, invoice.InvoiceID.String())
+	cancelURL := fmt.Sprintf("%s/payments/%s", baseURL, invoice.InvoiceID.String())
 
 	params := &stripe.CheckoutSessionParams{
 		Mode:               stripe.String(string(stripe.CheckoutSessionModePayment)),


### PR DESCRIPTION
Description

This PR addresses configuration mismatches in the Stripe implementation.

1. Webhook Compatibility:

    Change: Updated HandleStripeWebhook to use ConstructEventWithOptions with IgnoreAPIVersionMismatch: true.

    Reason: The Stripe Go SDK version pinned in go.mod differs slightly from the API version configured in the Stripe Dashboard. This flag prevents the webhook from failing signature verification due to this mismatch.

2. Redirect URLs:

    Change: Updated the success_url and cancel_url passed to the Checkout Session.

    From: .../payment/{id}?status=success

    To: .../payments/{id} (Removed query parameters and pluralized path).

    Reason: Aligns the backend redirects with the actual routes defined in the Frontend application.

Related Issue

N/A
Motivation and Context

    Stability: Without ignoring the version mismatch, legitimate payment webhooks were being rejected by the server, leading to "Paid" invoices remaining "Pending" in the database.

    UX: Users completing payment were hitting a 404 page because the return URL didn't match the frontend router.

How Has This Been Tested?

    Webhook Test:

        Triggered a checkout.session.completed event using the Stripe CLI.

        Verified that the server accepted the event (200 OK) even though the CLI version might differ from the SDK.

    Checkout Flow:

        Generated a checkout link.

        Completed the payment.

        Verified the browser redirected to /payments/{uuid} correctly.