### PR TITLE
fix(llm): Persist Tool Outputs as Hidden Context for History Awareness

### DIFF
--- a/internal/modules/llm/services/llm_services.go
+++ b/internal/modules/llm/services/llm_services.go
@@ -3,6 +3,7 @@ package llmservices
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -71,6 +72,7 @@ GOLDEN RULES (FOLLOW THEM OR FAIL):
 2. **SMART MAPPING:**
    - The user sees a simple numbered list (1, 2, 3...).
    - You see the UUIDs in the tool outputs (e.g., "[ID: 123...]").
+   - **HISTORY AWARENESS:** You may see "<!-- TOOL_OUTPUT ... -->" in the conversation history. These contain the UUIDs from previous searches. USE THEM to map the user's "1" or "2" to the correct ID.
    - IF the user selects "1", YOU MUST find the UUID for item #1 and use THAT UUID in the tool call.
    - NEVER send "1", "2", etc. as an ID to a tool.
    - If you are unsure which class it is, list the options again with simple numbers (1, 2, 3) and ask them to confirm the number.
@@ -114,6 +116,8 @@ Your final goal: The user books or cancels without knowing what an ID is.`, time
 
 	msg := resp.Choices[0].Message
 
+	var hiddenContext strings.Builder
+
 	for i := 0; i < 5 && len(msg.ToolCalls) > 0; i++ {
 		openaiMsgs = append(openaiMsgs, msg)
 
@@ -123,6 +127,8 @@ Your final goal: The user books or cancels without knowing what an ID is.`, time
 				if err != nil {
 					toolOutput = fmt.Sprintf("Error executing tool: %v", err)
 				}
+
+				hiddenContext.WriteString(fmt.Sprintf("\n<!-- TOOL_OUTPUT [%s]: %s -->", toolCall.Function.Name, toolOutput))
 
 				openaiMsgs = append(openaiMsgs, openai.ChatCompletionMessage{
 					Role:       openai.ChatMessageRoleTool,
@@ -149,7 +155,7 @@ Your final goal: The user books or cancels without knowing what an ID is.`, time
 	botMsg := &llmdomain.Message{
 		ConversationID: convo.ConversationID,
 		SenderRole:     llmdomain.RoleAssistant,
-		Content:        botContent,
+		Content:        botContent + hiddenContext.String(),
 		Metadata:       datatypes.JSON([]byte(`{}`)),
 		CreatedAt:      time.Now(),
 	}


### PR DESCRIPTION
### Description

This PR solves a critical "Memory Loss" issue where the AI would forget the UUIDs of items it just listed in the previous turn.

1. Hidden Context Persistence:

    Mechanism: The system now captures the raw output of every Tool Call (which contains the essential UUIDs) and appends it to the final Assistant Message using an HTML Comment format (``).

    Effect:

        For the User: The output remains invisible in the UI (since Markdown/HTML renderers hide comments), keeping the chat clean.

        For the AI: When the conversation history is loaded for the next message, the AI receives these comments, allowing it to "see" the UUIDs from previous turns.

2. System Prompt Update:

    Added a "HISTORY AWARENESS" rule instructing the Agent to explicitly look for these `` tags when mapping user selections (e.g., "Book option 1") to technical IDs.

### Related Issue

N/A
### Motivation and Context

    The Problem: Previously, if the AI fetched classes and replied "Here are your options: 1. Yoga...", it only saved that polite text to the DB. If the user then said "Book 1", the AI would fail because the UUIDs were lost in the transient tool execution and not saved in the conversation history.

    The Fix: By embedding the data as a hidden comment, we preserve the "State" of the previous search without cluttering the UI.

### How Has This Been Tested?

    Multi-Turn Booking:

        User: "Find classes for today." -> AI calls tool, finds UUID abc-123, replies "1. Yoga".

        Verified DB: The saved message contains 1. Yoga... .

        User: "Book the first one."

        Result: The AI successfully found abc-123 in the history and executed the booking.